### PR TITLE
feat(parser): implement v0.2 UX Semantic Layer support

### DIFF
--- a/src/dazzle/core/ir.py
+++ b/src/dazzle/core/ir.py
@@ -473,6 +473,8 @@ class PersonaVariant(BaseModel):
         show_aggregate: Aggregate metrics to display (e.g., critical_count)
         action_primary: Primary action surface for this persona
         read_only: Whether mutations are disabled
+        defaults: Default field values for forms (e.g., {"assigned_to": "current_user"})
+        focus: Workspace regions to emphasize for this persona
     """
 
     persona: str
@@ -484,6 +486,8 @@ class PersonaVariant(BaseModel):
     show_aggregate: list[str] = Field(default_factory=list)
     action_primary: str | None = None  # Surface reference
     read_only: bool = False
+    defaults: dict[str, Any] = Field(default_factory=dict)  # Field default values
+    focus: list[str] = Field(default_factory=list)  # Workspace regions to emphasize
 
     class Config:
         frozen = True
@@ -541,9 +545,7 @@ class UXSpec(BaseModel):
     class Config:
         frozen = True
 
-    def get_persona_variant(
-        self, user_context: dict[str, Any]
-    ) -> PersonaVariant | None:
+    def get_persona_variant(self, user_context: dict[str, Any]) -> PersonaVariant | None:
         """Get applicable persona variant for user context."""
         for variant in self.persona_variants:
             if variant.applies_to_user(user_context):
@@ -614,6 +616,7 @@ class WorkspaceRegion(BaseModel):
         display: Display mode (list, grid, timeline, map)
         action: Surface for quick action on items
         empty_message: Message when no data
+        group_by: Field to group data by for aggregation
         aggregates: Named aggregate expressions
     """
 
@@ -625,6 +628,7 @@ class WorkspaceRegion(BaseModel):
     display: DisplayMode = DisplayMode.LIST
     action: str | None = None  # Surface reference
     empty_message: str | None = None
+    group_by: str | None = None  # Field to group by
     aggregates: dict[str, str] = Field(default_factory=dict)  # metric_name: expr
 
     class Config:

--- a/src/dazzle/core/lexer.py
+++ b/src/dazzle/core/lexer.py
@@ -120,6 +120,12 @@ class TokenType(Enum):
     GRID = "grid"
     TIMELINE = "timeline"
 
+    # Additional v0.2 keywords
+    DEFAULTS = "defaults"
+    FOCUS = "focus"
+    GROUP_BY = "group_by"
+    WHERE = "where"
+
     # Comparison operators (for condition expressions)
     NOT_EQUALS = "!="
     GREATER_THAN = ">"
@@ -150,6 +156,12 @@ class TokenType(Enum):
     DOT = "."
     SLASH = "/"
     QUESTION = "?"
+
+    # Arithmetic operators (for aggregate expressions)
+    PLUS = "+"
+    MINUS = "-"
+    STAR = "*"
+    PERCENT = "%"
 
     # Special
     NEWLINE = "NEWLINE"
@@ -255,6 +267,11 @@ KEYWORDS = {
     "list",
     "grid",
     "timeline",
+    # Additional v0.2 keywords
+    "defaults",
+    "focus",
+    "group_by",
+    "where",
     # Comparison/logical keywords
     "in",
     "not",
@@ -579,12 +596,9 @@ class Lexer:
                     self.advance()
                     self.tokens.append(Token(TokenType.ARROW, "->", token_line, token_col))
                 else:
-                    raise make_parse_error(
-                        f"Unexpected character: {ch!r}",
-                        self.file,
-                        token_line,
-                        token_col,
-                    )
+                    # Standalone minus operator (for arithmetic)
+                    self.advance()
+                    self.tokens.append(Token(TokenType.MINUS, "-", token_line, token_col))
 
             elif ch == "<":
                 if self.peek_char() == "-":
@@ -604,6 +618,18 @@ class Lexer:
                 else:
                     self.advance()
                     self.tokens.append(Token(TokenType.LESS_THAN, "<", token_line, token_col))
+
+            elif ch == "+":
+                self.advance()
+                self.tokens.append(Token(TokenType.PLUS, "+", token_line, token_col))
+
+            elif ch == "*":
+                self.advance()
+                self.tokens.append(Token(TokenType.STAR, "*", token_line, token_col))
+
+            elif ch == "%":
+                self.advance()
+                self.tokens.append(Token(TokenType.PERCENT, "%", token_line, token_col))
 
             else:
                 raise make_parse_error(


### PR DESCRIPTION
- Add arithmetic operators (*, +, -, %) to lexer for aggregate expressions
- Add v0.2 keywords (defaults, focus, group_by, where) to lexer
- Fix keyword/identifier conflicts in enum values, index fields, and section names
- Add defaults and focus fields to PersonaVariant IR
- Add group_by field to WorkspaceRegion IR
- Update parser to handle defaults and focus directives in persona blocks
- Update parser to handle group_by in workspace regions
- Allow keywords as identifiers in appropriate contexts

This enables full v0.2 DSL support including:
- UX blocks with attention signals and personas
- Workspaces with grouped aggregations
- Arithmetic expressions in aggregates
- Field defaults and focus regions for personas

🤖 Generated with [Claude Code](https://claude.com/claude-code)