### PR TITLE
Fix: Include dazzle_ui templates in package distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,8 @@ namespaces = false
 [tool.setuptools.package-data]
 dazzle = ["py.typed"]
 "dazzle.examples" = ["**/*"]
+# Dazzle UI templates (Jinja2 HTML templates for site pages, components, etc.)
+"dazzle_ui.templates" = ["**/*.html", "**/*.css", "**/*.js"]
 # Dazzle UI runtime static files (JS, CSS)
 "dazzle_ui.runtime.static" = ["**/*.js", "**/*.css"]
 


### PR DESCRIPTION
## Summary

- Fixes missing Jinja2 templates in distributed wheel package
- SiteSpec pages (landing, pricing, etc.) now render correctly in production deployments

## Problem

The `dazzle_ui/templates/` directory containing Jinja2 HTML templates was not being included in the wheel package. This caused:
- Site pages to fail to render (404 on `/`, `/pricing`, etc.)
- `get_jinja_env().list_templates()` returning 0 templates in production
- SiteSpec features to be effectively broken for deployed apps

## Solution

Added package-data entry in `pyproject.toml`:
```toml
"dazzle_ui.templates" = ["**/*.html", "**/*.css", "**/*.js"]
```

## Test plan

- [ ] Build wheel locally and verify templates are included
- [ ] Deploy to Heroku and verify site pages render

🤖 Generated with [Claude Code](https://claude.com/claude-code)