### PR TITLE
Fix: Correct package-data pattern for dazzle_ui templates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,8 @@ namespaces = false
 dazzle = ["py.typed"]
 "dazzle.examples" = ["**/*"]
 # Dazzle UI templates (Jinja2 HTML templates for site pages, components, etc.)
-"dazzle_ui.templates" = ["**/*.html", "**/*.css", "**/*.js"]
+# Note: templates/ is a data directory, not a Python package, so include from parent
+"dazzle_ui" = ["templates/**/*.html", "templates/**/*.css", "templates/**/*.js"]
 # Dazzle UI runtime static files (JS, CSS)
 "dazzle_ui.runtime.static" = ["**/*.js", "**/*.css"]
 


### PR DESCRIPTION
## Summary

Fixes the package-data pattern for including Jinja2 templates in the wheel.

## Problem

PR #92 used `"dazzle_ui.templates"` as the package-data key, but since `templates/` is a data directory (no `__init__.py`), setuptools doesn't find the files.

## Solution

Use the parent package with relative paths:
```toml
"dazzle_ui" = ["templates/**/*.html", "templates/**/*.css", "templates/**/*.js"]
```

## Test plan

- [ ] Build wheel locally: `pip wheel . --no-deps`
- [ ] Verify templates included: `unzip -l dist/dazzle-*.whl | grep templates`
- [ ] Deploy to Heroku and confirm site pages render

🤖 Generated with [Claude Code](https://claude.com/claude-code)