### PR TITLE
Fix: Include HTML page routes for sitespec pages

### DIFF
--- a/src/dazzle_back/runtime/server.py
+++ b/src/dazzle_back/runtime/server.py
@@ -1128,13 +1128,24 @@ class DNRBackendApp:
 
         # Initialize site routes (v0.16.0)
         if self._sitespec_data:
-            from dazzle_back.runtime.site_routes import create_site_routes
+            from dazzle_back.runtime.site_routes import (
+                create_site_page_routes,
+                create_site_routes,
+            )
 
+            # API routes for site data (/_site/*)
             site_router = create_site_routes(
                 sitespec_data=self._sitespec_data,
                 project_root=self._project_root,
             )
             self._app.include_router(site_router)
+
+            # HTML page routes (/, /features, /pricing, etc.)
+            page_router = create_site_page_routes(
+                sitespec_data=self._sitespec_data,
+                project_root=self._project_root,
+            )
+            self._app.include_router(page_router)
 
         # Initialize messaging channels (v0.9)
         if self._enable_channels and self.spec.channels:


### PR DESCRIPTION
## Summary

- Adds HTML page routes for sitespec pages (/, /features, /pricing, etc.)
- Previously only API endpoints (/_site/*) were registered

## Problem

Sitespec pages returned 404 because only the API endpoints were being registered, not the actual HTML page routes.

## Solution

Include both routers from `site_routes.py`:
- `create_site_routes()` - API endpoints for SPA mode
- `create_site_page_routes()` - HTML pages for SSR mode

## Test plan

- [ ] Deploy to Heroku
- [ ] Verify https://www.cyfutureuk.com/ shows landing page
- [ ] Verify https://www.cyfutureuk.com/pricing shows pricing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)