### PR TITLE
feat: Add DAZZLE_ENABLE_PROCESSES env var

### DIFF
--- a/src/dazzle_back/runtime/server.py
+++ b/src/dazzle_back/runtime/server.py
@@ -1542,6 +1542,7 @@ def create_app_factory() -> FastAPI:
         REDIS_URL: Redis connection URL (for sessions/cache)
         DAZZLE_ENV: Environment name (development/staging/production)
         DAZZLE_SECRET_KEY: Secret key for sessions/tokens
+        DAZZLE_ENABLE_PROCESSES: Enable/disable process workflows (default: "true")
 
     Usage:
         uvicorn dazzle_back.runtime.server:create_app_factory --factory --host 0.0.0.0 --port $PORT
@@ -1609,6 +1610,9 @@ def create_app_factory() -> FastAPI:
     enable_dev_mode = dazzle_env == "development"
     enable_test_mode = dazzle_env in ("development", "test")
 
+    # Process workflow support (can be disabled via env var)
+    enable_processes = os.environ.get("DAZZLE_ENABLE_PROCESSES", "true").lower() == "true"
+
     # Parse DSL and build spec
     try:
         dsl_files = discover_dsl_files(project_root, manifest)
@@ -1665,7 +1669,7 @@ def create_app_factory() -> FastAPI:
         scenarios=[],
         sitespec_data=sitespec_data,
         project_root=project_root,
-        enable_processes=True,
+        enable_processes=enable_processes,
         process_db_path=project_root / ".dazzle" / "processes.db",
         enable_console=enable_dev_mode,
     )


### PR DESCRIPTION
## Summary

Adds environment variable to enable/disable process workflow support.

### Use Cases

- Deployments that don't need process execution
- Apps that handle process workflows externally (e.g., via separate Celery workers)
- Simplified deployments without SQLite process database

### Usage

```bash
# Disable process workflows
export DAZZLE_ENABLE_PROCESSES=false

# Enable (default)
export DAZZLE_ENABLE_PROCESSES=true
```

### Default Behavior

Processes are **enabled by default** (`"true"`) to maintain backwards compatibility.

## Test Plan

- [ ] Verify processes work when env var not set (default)
- [ ] Verify processes disabled when `DAZZLE_ENABLE_PROCESSES=false`
- [ ] Verify app starts without process-related errors when disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)