### PR TITLE
Add Redis cache layer to MappingExecutor

### DIFF
--- a/src/dazzle_back/runtime/server.py
+++ b/src/dazzle_back/runtime/server.py
@@ -1091,12 +1091,14 @@ class DazzleBackendApp:
                     if isinstance(entity_data, dict)
                     else (entity_data.__dict__ if hasattr(entity_data, "__dict__") else {})
                 )
+                force_refresh = request.query_params.get("force") == "1"
                 result = await _executor.execute_manual(
                     _int_name,
                     _map_name,
                     data,
                     entity_name=_entity_name,
                     entity_id=entity_id,
+                    force_refresh=force_refresh,
                 )
 
                 # htmx requests: redirect back to the detail page (#341)
@@ -1112,6 +1114,7 @@ class DazzleBackendApp:
                     "success": result.success,
                     "message": result.message if hasattr(result, "message") else "",
                     "mapped_fields": result.mapped_fields or {},
+                    "cache_hit": result.cache_hit,
                 }
 
             return _handler


### PR DESCRIPTION
## Summary

- Adds `IntegrationCache` class to `mapping_executor.py` — Redis-backed cache-through layer for external API responses
- GET responses cached with 24h TTL, 60s dedup locks prevent duplicate in-flight calls
- Transparent: auto-detects `REDIS_URL`, gracefully degrades to no-op without Redis
- Manual trigger routes gain `?force=1` query param to bypass cache
- `MappingResult.cache_hit` field for observability

## Motivation

Integration triggers (e.g. Companies House lookups) call external APIs synchronously on every button click. With no caching, repeated lookups for the same entity hit rate limits and add unnecessary latency. This is a common pattern across any Dazzle project using integrations.

## Design

Cache key: `integration:{name}:{mapping}:{url_hash}` — scoped per integration and mapping, keyed on the interpolated URL (which includes entity-specific data like company number).

Only GET requests are cached. POST/PUT/PATCH (mutations) always go through to the API.

Dedup lock (`integration:lock:{url_hash}`, 60s TTL) prevents multiple users clicking the same trigger button from spawning parallel API calls.

## Test plan

- [ ] Verify cache auto-creates from `REDIS_URL` (Heroku rediss://)
- [ ] Verify graceful degradation without Redis (local dev)
- [ ] Trigger a manual GET integration, verify cached response on second call
- [ ] Verify `?force=1` bypasses cache
- [ ] Verify POST/PUT mappings are never cached
- [ ] Run DSL API tests — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)