### PR TITLE
Potential fix for code scanning alert no. 56: Incomplete URL substring sanitization

### DIFF
--- a/src/dazzle_back/control_plane/app.py
+++ b/src/dazzle_back/control_plane/app.py
@@ -11,6 +11,7 @@ import logging
 import os
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
 from fastapi import FastAPI
 
@@ -32,8 +33,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Initialize Redis connection
     redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379")
 
-    # Handle Heroku/AWS Redis SSL
-    ssl_cert_reqs = None if "amazonaws.com" in redis_url else "required"
+    # Handle Heroku/AWS Redis SSL based on parsed hostname
+    parsed_url = urlparse(redis_url)
+    host = parsed_url.hostname or ""
+    is_aws_redis = host == "amazonaws.com" or host.endswith(".amazonaws.com")
+    ssl_cert_reqs = None if is_aws_redis else "required"
     redis_client: redis.Redis = redis.from_url(
         redis_url,
         decode_responses=True,


### PR DESCRIPTION
Potential fix for [https://github.com/manwithacat/dazzle/security/code-scanning/56](https://github.com/manwithacat/dazzle/security/code-scanning/56)

In general, to fix this kind of issue you should parse the URL and make your decision based on structured components such as the hostname, rather than checking for a substring in the full URL string. For hostname checks, ensure you compare the hostname or use a suffix check on the hostname string itself, not on the entire URL.

Here, the desired behavior is: if the Redis host is an AWS/Heroku managed Redis instance (ending in `amazonaws.com`), then set `ssl_cert_reqs=None`, otherwise require certificates. The minimal, non-breaking fix is to parse `redis_url` with `urllib.parse.urlparse`, extract `hostname`, and check whether that hostname ends with `.amazonaws.com` or equals `amazonaws.com`. This preserves the intent while avoiding matches where `amazonaws.com` only appears in the path, username, password, or query. If parsing fails or no hostname exists, we should fall back to the more secure default `ssl_cert_reqs="required"`.

Concretely:
- Add an import for `urlparse` from `urllib.parse` at the top of `src/dazzle_back/control_plane/app.py`.
- Replace the line `ssl_cert_reqs = None if "amazonaws.com" in redis_url else "required"` with:
  - parse `redis_url`,
  - get `hostname = parsed.hostname or ""`,
  - set `is_aws_host = hostname == "amazonaws.com" or hostname.endswith(".amazonaws.com")`,
  - then `ssl_cert_reqs = None if is_aws_host else "required"`.

This keeps all existing functionality except that only true `amazonaws.com` hosts will trigger the relaxed SSL behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
