### PR TITLE
fix(validation): 3 fuzz-found framework gaps (#1411, #1412, #1414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.83.1] - 2026-06-18
+
+### Fixed
+- **Three framework validation/CLI gaps surfaced by the cross-app fuzz sweep** (validate/lint miss runtime-breaking conditions):
+  - **`lint` dead-construct detector ignored `subtype_panel` branch `include_surface` refs** (#1411) — a surface used only via `subtype_panel: when … include surface X` was wrongly flagged dead. `_detect_dead_constructs()` now walks `SubtypePanelSpec.branches[].include_surface`.
+  - **`validate` didn't catch an undefined surface in a workspace region `action:`** (#1412) — a typo'd `action:` shipped a runtime row-click to a dead URL (`ux.py` skipped it as "caught elsewhere" — it wasn't). Now a validation error; path-style action_grid CTAs (starting `/`) are exempted. Also fixed the dangling `action: doc_list` in `fixtures/signing_validation`.
+  - **CLI raw `FileNotFoundError` traceback when `dazzle.toml` is missing** (#1414) — `load_manifest()` now raises a friendly `DazzleError` ("No dazzle.toml found … run from a project root or `dazzle init`"), which validate/lint/serve already print cleanly.
+
+  ### Agent Guidance
+  - A workspace region `action:` must name a real surface — `dazzle validate` now errors on dangling refs. Use a path (`/…`) only for action_grid CTAs.
+
 ## [0.83.0] - 2026-06-17
 
 ### Changed

--- a/fixtures/signing_validation/dsl/app.dsl
+++ b/fixtures/signing_validation/dsl/app.dsl
@@ -22,5 +22,4 @@ workspace docs_dashboard "Documents":
     source: TestDoc
     sort: id asc
     display: list
-    action: doc_list
     empty: "No documents"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dazzle-dsl"
-version = "0.83.0"
+version = "0.83.1"
 description = "DAZZLE — declarative SaaS framework with built-in compliance (SOC 2, ISO 27001), provable RBAC, and graph features"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/dazzle/core/manifest.py
+++ b/src/dazzle/core/manifest.py
@@ -7,6 +7,7 @@ from importlib.metadata import version
 from pathlib import Path
 
 from dazzle.core.db_url import normalise_postgres_scheme
+from dazzle.core.errors import DazzleError
 
 _FRAGMENT_CHROME_WARNED = False
 
@@ -784,6 +785,15 @@ def check_framework_version(manifest: ProjectManifest) -> None:
 
 
 def load_manifest(path: Path) -> ProjectManifest:
+    # #1414: a missing dazzle.toml used to raise a raw FileNotFoundError that
+    # escaped the CLI's `except (ParseError, DazzleError)` handlers as an
+    # unfriendly traceback. Raise a DazzleError (which validate/lint/serve all
+    # catch and print cleanly) instead.
+    if not path.exists():
+        raise DazzleError(
+            f"No dazzle.toml found at {path}. "
+            "Run from a Dazzle project root, or `dazzle init` to create one."
+        )
     data = tomllib.loads(path.read_text(encoding="utf-8"))
 
     project = data.get("project", {})

--- a/src/dazzle/core/validation/extended.py
+++ b/src/dazzle/core/validation/extended.py
@@ -123,6 +123,19 @@ def _detect_dead_constructs(appspec: ir.AppSpec) -> list[str]:
             if proc_step.human_task and proc_step.human_task.surface:
                 used_surfaces.add(proc_step.human_task.surface)
 
+    # Surfaces included via subtype_panel branches (#1411): a surface
+    # referenced only through `subtype_panel: when ... include surface X` is
+    # alive. Without this walk, _detect_dead_constructs false-flags such a
+    # surface as dead (caught by the fuzz sweep on fixtures/asset_registry).
+    for surface in appspec.surfaces:
+        for section in surface.sections:
+            panel = section.subtype_panel
+            if panel is None:
+                continue
+            for branch in panel.branches:
+                if branch.include_surface:
+                    used_surfaces.add(branch.include_surface)
+
     # Surfaces belonging to entities used in workspace regions are implicitly
     # alive — entity CRUD surfaces are navigable from workspace detail pages
     # even when not explicitly wired to a workspace action.

--- a/src/dazzle/core/validation/ux.py
+++ b/src/dazzle/core/validation/ux.py
@@ -418,11 +418,27 @@ def validate_workspace_region_actions(appspec: ir.AppSpec) -> tuple[list[str], l
 
     for workspace in appspec.workspaces:
         for region in workspace.regions:
-            if not region.action or not region.source:
+            if not region.action:
                 continue
             action_surface = surfaces_by_name.get(region.action)
             if action_surface is None:
-                continue  # unknown surface is caught elsewhere
+                # #1412: an `action:` referencing a non-existent surface was
+                # silently ignored (the old comment claimed it was "caught
+                # elsewhere" — it wasn't, so a typo'd ref shipped a runtime
+                # row-click to a dead URL). A path-style action (an action_grid
+                # CTA, which starts with "/") is legitimately not a surface
+                # name, so only flag identifier-shaped dangling refs.
+                if "/" not in region.action:
+                    region_label = getattr(region, "name", None) or region.source or "?"
+                    errors.append(
+                        f"Workspace '{workspace.name}' region '{region_label}' declares "
+                        f"`action: {region.action}` but no surface named "
+                        f"'{region.action}' exists — the row-click action would "
+                        f"navigate to a non-existent surface at runtime."
+                    )
+                continue
+            if not region.source:
+                continue  # FK-threading check below requires a source entity
             target_entity = action_surface.entity_ref
             if not target_entity or target_entity == region.source:
                 continue  # same-entity action — no FK needed

--- a/tests/unit/test_asset_registry_fixture.py
+++ b/tests/unit/test_asset_registry_fixture.py
@@ -114,3 +114,19 @@ class TestAssetRegistrySurfaces:
         vd = next(s for s in appspec.surfaces if s.name == "vehicle_detail")
         field_names = {e.field_name for e in vd.sections[0].elements}
         assert field_names == {"wheels", "vin", "fuel_type"}
+
+
+def test_subtype_panel_include_surfaces_not_flagged_dead() -> None:
+    """#1411: surfaces referenced only via a `subtype_panel` branch's
+    `include surface X` are alive — the extended-lint dead-construct detector
+    must not flag them. (Regression: the fuzz sweep caught these as false dead.)
+    """
+    from dazzle.core.lint import lint_appspec
+
+    appspec = _load_fixture()
+    _errors, warnings, _relevance = lint_appspec(appspec, extended=True)
+    dead = [w for w in warnings if "Dead construct" in w and "surface" in w]
+    for name in ("building_detail", "equipment_detail", "vehicle_detail"):
+        assert not any(name in w for w in dead), (
+            f"surface '{name}' is used via subtype_panel but was flagged dead: {dead}"
+        )

--- a/tests/unit/test_manifest_extensions.py
+++ b/tests/unit/test_manifest_extensions.py
@@ -65,3 +65,15 @@ def test_non_string_entries_filtered(tmp_path: Path) -> None:
         "app.routes.graph:router",
         "app.routes.search:router",
     ]
+
+
+def test_missing_dazzle_toml_raises_dazzle_error(tmp_path: Path) -> None:
+    """#1414: a missing dazzle.toml raises a friendly DazzleError (which the CLI
+    catches and prints cleanly) instead of a raw FileNotFoundError traceback."""
+    import pytest
+
+    from dazzle.core.errors import DazzleError
+
+    missing = tmp_path / "dazzle.toml"  # never created
+    with pytest.raises(DazzleError, match="No dazzle.toml found"):
+        load_manifest(missing)

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -1728,3 +1728,28 @@ persona teacher "Teacher":
         assert any("missing" in e for e in errors), (
             f"Expected error mentioning 'missing' nav, got {errors}"
         )
+
+
+def test_workspace_region_action_undefined_surface_is_error(tmp_path) -> None:
+    """#1412: a workspace region `action:` that references a non-existent
+    surface is a validation error (it used to be silently ignored, shipping a
+    runtime row-click to a dead URL — caught by the fuzz sweep)."""
+    from dazzle.core.parser import parse_modules
+    from dazzle.core.validator import validate_workspace_region_actions
+
+    dsl = tmp_path / "app.dsl"
+    dsl.write_text(
+        "module t\n"
+        'app t "T"\n'
+        'entity Doc "Doc":\n'
+        "  id: uuid pk\n"
+        "  title: str(100)\n"
+        'workspace board "Board":\n'
+        "  docs:\n"
+        "    source: Doc\n"
+        "    display: list\n"
+        "    action: nonexistent_surface\n"
+    )
+    appspec = build_appspec(parse_modules([dsl]), "t")
+    errors, _warnings = validate_workspace_region_actions(appspec)
+    assert any("nonexistent_surface" in e for e in errors), errors

--- a/uv.lock
+++ b/uv.lock
@@ -990,7 +990,7 @@ wheels = [
 
 [[package]]
 name = "dazzle-dsl"
-version = "0.83.0"
+version = "0.83.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Closes #1411, #1412, #1414. Three validate/lint/CLI gaps the cross-app fuzz sweep surfaced (validate misses runtime-breaking conditions). See CHANGELOG [0.83.1]. mypy clean; 3 regression tests added; full non-e2e suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)