### PR TITLE
feat(runtime): serve-time warning for unregistered custom renderers (#1413)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.83.2] - 2026-06-18
+
+### Added
+- **Serve-time warning for declared-but-unregistered custom renderers** (#1413). A renderer declared in `dazzle.toml` `[renderers] extra` whose runtime handler is never wired passes `validate`/`lint` but 500s with a `FragmentError` at first request. The runtime now compares the declared set against `services.renderer_registry.registered_names()` after all startup hooks and logs a boot warning naming the orphans + the fix (`services.renderer_registry.register(...)` via `register_lifespan_hook`) — non-fatal, surfaced at the moment it matters. (Found by the cross-app fuzz sweep; prerequisite for #1392.)
+
 ## [0.83.1] - 2026-06-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dazzle-dsl"
-version = "0.83.1"
+version = "0.83.2"
 description = "DAZZLE — declarative SaaS framework with built-in compliance (SOC 2, ISO 27001), provable RBAC, and graph features"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/dazzle/back/runtime/server.py
+++ b/src/dazzle/back/runtime/server.py
@@ -475,6 +475,51 @@ class DazzleBackendApp:
         declared = load_manifest(manifest_path).capabilities.enabled
         return resolve_capabilities(list(declared))
 
+    def _warn_unregistered_renderers(self) -> None:
+        """#1413: warn at boot when a custom renderer declared in dazzle.toml
+        ``[renderers] extra`` has no runtime handler registered.
+
+        Declaring a renderer (link-time, validated by build_appspec) and
+        registering its handler (runtime, ``services.renderer_registry.register``)
+        are separate steps. A declared-but-unregistered renderer passes
+        ``dazzle validate``/``lint`` but 500s with a FragmentError at first
+        request. Surface the gap at the moment it matters — boot — without
+        failing the boot (warning, not error).
+        """
+        if self._project_root is None or self._app is None:
+            return
+        manifest_path = self._project_root / "dazzle.toml"
+        if not manifest_path.is_file():
+            return
+        from dazzle.core.manifest import load_manifest
+
+        try:
+            declared = load_manifest(manifest_path).renderers.extra
+        except (ValueError, OSError):
+            # Best-effort warning only — a malformed/unreadable manifest is
+            # surfaced loudly by the appspec build that already ran; don't let
+            # this advisory check perturb boot.
+            return
+        if not declared:
+            return
+        services = getattr(self._app.state, "services", None)
+        registry = getattr(services, "renderer_registry", None)
+        if registry is None:
+            return
+        registered = set(registry.registered_names())
+        orphans = sorted(r for r in declared if r not in registered)
+        if orphans:
+            logger.warning(
+                "[dazzle] custom renderer(s) declared in dazzle.toml "
+                "[renderers] extra but never registered at runtime: %s — they "
+                "will 500 (FragmentError) at request time. Wire "
+                "services.renderer_registry.register(name=..., handler=...) at "
+                "startup (e.g. your register_all() via register_lifespan_hook). "
+                "Declared-but-unregistered renderers pass validate/lint but "
+                "fail at request (#1413).",
+                ", ".join(orphans),
+            )
+
     def _build_subsystem_context(self, auth_dep: Any = None, optional_auth_dep: Any = None) -> Any:
         """Build SubsystemContext from current DazzleBackendApp state."""
         from dazzle.back.runtime.subsystems import SubsystemContext
@@ -580,6 +625,10 @@ class DazzleBackendApp:
         # framework is up. Each emits a deprecation warning pointing at
         # dazzle.register_lifespan_hook, the supported path.
         await run_legacy_router_events(app, "startup")
+        # #1413: after all registration (framework defaults + project
+        # register_all via startup hooks/legacy events), warn on any custom
+        # renderer declared in dazzle.toml that never got a runtime handler.
+        self._warn_unregistered_renderers()
         try:
             yield
         finally:

--- a/tests/unit/test_renderer_registration_warning_1413.py
+++ b/tests/unit/test_renderer_registration_warning_1413.py
@@ -1,0 +1,48 @@
+"""#1413: a custom renderer declared in dazzle.toml `[renderers] extra` but
+never registered at runtime must emit a boot-time warning (it would otherwise
+pass validate/lint and 500 with a FragmentError at first request).
+
+Exercises ``DazzleBackendApp._warn_unregistered_renderers`` against the real
+``fixtures/custom_renderer`` manifest (which declares ``word_cloud`` /
+``feedback_detail`` but never wires their handlers), using a duck-typed stand-in
+for ``self`` so no DB/subprocess boot is needed.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+from dazzle.back.runtime.server import DazzleBackendApp
+
+_FIXTURE = Path(__file__).resolve().parents[2] / "fixtures" / "custom_renderer"
+
+
+def _stub(registered: list[str]) -> SimpleNamespace:
+    """Minimal stand-in exposing only the attrs the method reads."""
+    registry = SimpleNamespace(registered_names=lambda: list(registered))
+    services = SimpleNamespace(renderer_registry=registry)
+    return SimpleNamespace(
+        _project_root=_FIXTURE,
+        _app=SimpleNamespace(state=SimpleNamespace(services=services)),
+    )
+
+
+def test_declared_but_unregistered_renderer_warns(caplog) -> None:
+    # Only the framework default "fragment" is registered; the fixture's
+    # declared customs (word_cloud, feedback_detail) are orphans.
+    stub = _stub(registered=["fragment"])
+    with caplog.at_level(logging.WARNING):
+        DazzleBackendApp._warn_unregistered_renderers(stub)  # type: ignore[arg-type]
+    warnings = " ".join(r.message for r in caplog.records)
+    assert "never registered at runtime" in warnings, caplog.text
+    assert "word_cloud" in warnings and "feedback_detail" in warnings, caplog.text
+
+
+def test_no_warning_when_all_declared_renderers_registered(caplog) -> None:
+    # When the customs ARE registered, no orphan warning fires.
+    stub = _stub(registered=["fragment", "word_cloud", "feedback_detail"])
+    with caplog.at_level(logging.WARNING):
+        DazzleBackendApp._warn_unregistered_renderers(stub)  # type: ignore[arg-type]
+    assert not any("never registered at runtime" in r.message for r in caplog.records), caplog.text

--- a/uv.lock
+++ b/uv.lock
@@ -990,7 +990,7 @@ wheels = [
 
 [[package]]
 name = "dazzle-dsl"
-version = "0.83.1"
+version = "0.83.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Closes #1413. Serve-time boot warning when a dazzle.toml-declared custom renderer has no runtime handler (passes validate/lint but 500s at request). Non-fatal; names the orphans + fix. CHANGELOG [0.83.2]. Verified on fixtures/custom_renderer; regression tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)