### PR TITLE
fix(#1472): aggregate `in [...]` where-clause silently returned 0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -374,4 +374,4 @@ Example: `examples/ops_dashboard` has working `bar_chart` (FK `group_by: system`
 - **KG re-seeding**: `ensure_seeded()` checks a version key; bump it in `seed.py` when TOML data changes.
 
 ---
-**Version**: 0.87.0 | **Python**: 3.12+ | **Status**: Production Ready
+**Version**: 0.87.1 | **Python**: 3.12+ | **Status**: Production Ready

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.87.1] - 2026-06-25
+
+### Fixed
+- **#1472: aggregate `count(... where <field> in [a, b, c])` silently returned 0.** A list (`in` / `not in`) where-clause in a region `aggregate` passed `dazzle validate` but fetched 0 at runtime — only `=` / `!=` worked. Root cause: `condition_expr_to_scope_predicate` expanded a list into per-element `ColumnCheck`s but **kept the `IN` operator on each single-literal element**, compiling to `"col" IN %s` with a *scalar* bind — invalid SQL the count fetcher swallowed to 0. Now `x in [a, b]` → `(x = a) OR (x = b)` and `x not in [a, b]` → `(x != a) AND (x != b)` (correct De Morgan; the previous code also wrongly OR-combined `not in`). `in []` compiles to `FALSE`. Worst-kind bug — passed validate, "0" looked plausible, shipped wrong numbers to dashboards.
+
+### Agent Guidance
+- **`in [...]` now works in aggregate where-clauses** (region `aggregate:` / `count(... where ...)`), at parity with region/list filters. No need to rewrite a set membership as repeated `= x` comparisons. Verified at the SQL-compilation layer (`tests/unit/test_condition_to_predicate.py`): a list expands to a parameterized `= %s` per branch, never `IN %s`.
+
 ## [0.87.0] - 2026-06-25
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # DAZZLE Development Roadmap
 
 **Last Updated**: 2026-06-16
-**Current Version**: v0.87.0
+**Current Version**: v0.87.1
 
 For past releases, see [CHANGELOG.md](CHANGELOG.md).
 

--- a/homebrew/dazzle.rb
+++ b/homebrew/dazzle.rb
@@ -10,10 +10,10 @@ class Dazzle < Formula
 
   desc "DSL-first application framework with LLM-assisted development"
   homepage "https://github.com/manwithacat/dazzle"
-  version "0.87.0"
+  version "0.87.1"
   license "MIT"
 
-  url "https://github.com/manwithacat/dazzle/archive/refs/tags/v0.87.0.tar.gz"
+  url "https://github.com/manwithacat/dazzle/archive/refs/tags/v0.87.1.tar.gz"
   sha256 "PLACEHOLDER_SOURCE_SHA256"
 
   # pydantic-core requires Rust to build from source, so use pre-built wheels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dazzle-dsl"
-version = "0.87.0"
+version = "0.87.1"
 description = "DAZZLE — declarative SaaS framework with built-in compliance (SOC 2, ISO 27001), provable RBAC, and graph features"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/dazzle/core/ir/condition_to_predicate.py
+++ b/src/dazzle/core/ir/condition_to_predicate.py
@@ -96,11 +96,22 @@ def condition_expr_to_scope_predicate(expr: ConditionExpr | None) -> ScopePredic
     if val.is_list and val.values is not None:
         # IN / NOT IN against a list of literals. ScopePredicate's
         # ColumnCheck stores a single ValueRef, so a multi-value list
-        # expands to an OR-composite of individual ColumnChecks —
-        # matches parse_aggregate_where's behaviour.
+        # expands to a boolean composite of per-element checks. Each
+        # element compares against ONE literal, so it must use `=` / `!=`
+        # — NOT the list operator. Keeping `IN`/`NOT IN` here compiled to
+        # `col IN %s` with a scalar bind: invalid SQL that the count
+        # fetcher swallowed, silently returning 0 (#1472). De Morgan:
+        #   `x in [a, b]`     → (x = a) OR  (x = b)
+        #   `x not in [a, b]` → (x != a) AND (x != b)
+        is_not_in = op is CompOp.NOT_IN
+        elem_op = CompOp.NEQ if is_not_in else CompOp.EQ
+        bool_op = BoolOp.AND if is_not_in else BoolOp.OR
         return BoolComposite.make(
-            BoolOp.OR,
-            [ColumnCheck(field=field_name, op=op, value=ValueRef(literal=v)) for v in val.values],
+            bool_op,
+            [
+                ColumnCheck(field=field_name, op=elem_op, value=ValueRef(literal=v))
+                for v in val.values
+            ],
         )
 
     if val.is_date_expr:

--- a/src/dazzle/mcp/semantics_kb/core.toml
+++ b/src/dazzle/mcp/semantics_kb/core.toml
@@ -3,7 +3,7 @@
 
 [meta]
 category = "Core Constructs"
-version = "0.87.0"
+version = "0.87.1"
 
 [concepts.entity]
 category = "Core Construct"

--- a/tests/unit/test_condition_to_predicate.py
+++ b/tests/unit/test_condition_to_predicate.py
@@ -98,11 +98,61 @@ def test_in_list_expands_to_or_of_column_checks() -> None:
         )
     )
     pred = condition_expr_to_scope_predicate(expr)
-    # IN list → OR of ColumnChecks (matches parse_aggregate_where).
+    # IN list → OR of equality ColumnChecks.
     assert isinstance(pred, BoolComposite)
     assert pred.op == BoolOp.OR
     assert all(isinstance(c, ColumnCheck) for c in pred.children)
     assert {c.value.literal for c in pred.children} == {"open", "doing"}
+
+
+def test_in_list_children_use_equality_op_not_in() -> None:
+    # #1472: each expanded child compares against a SINGLE literal, so it
+    # must use `=`, not `IN`. Keeping `IN` produces `col IN %s` with a
+    # scalar bind — invalid SQL that silently fetched 0 on dashboards.
+    expr = ConditionExpr(
+        comparison=Comparison(
+            field="status",
+            operator=ComparisonOperator.IN,
+            value=ConditionValue(values=["reviewed", "released", "analysed"]),
+        )
+    )
+    pred = condition_expr_to_scope_predicate(expr)
+    assert all(c.op == CompOp.EQ for c in pred.children)
+
+
+def test_in_list_compiles_to_valid_equality_sql() -> None:
+    # #1472: the compiled SQL must be `= %s` per branch, never `IN %s`.
+    from dazzle.core.ir.fk_graph import FKGraph
+    from dazzle.http.runtime.predicate_compiler import compile_predicate
+
+    expr = ConditionExpr(
+        comparison=Comparison(
+            field="status",
+            operator=ComparisonOperator.IN,
+            value=ConditionValue(values=["reviewed", "released"]),
+        )
+    )
+    pred = condition_expr_to_scope_predicate(expr)
+    sql, params = compile_predicate(pred, "AssessmentEvent", FKGraph())
+    assert "IN %s" not in sql
+    assert sql.count("= %s") == 2
+    assert params == ["reviewed", "released"]
+
+
+def test_not_in_list_expands_to_and_of_inequality() -> None:
+    # #1472: `not in [a, b]` means `field != a AND field != b` — AND of
+    # NEQ, not OR of NOT_IN.
+    expr = ConditionExpr(
+        comparison=Comparison(
+            field="status",
+            operator=ComparisonOperator.NOT_IN,
+            value=ConditionValue(values=["archived", "deleted"]),
+        )
+    )
+    pred = condition_expr_to_scope_predicate(expr)
+    assert isinstance(pred, BoolComposite)
+    assert pred.op == BoolOp.AND
+    assert all(c.op == CompOp.NEQ for c in pred.children)
 
 
 def test_role_check_rejected() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -912,7 +912,7 @@ wheels = [
 
 [[package]]
 name = "dazzle-dsl"
-version = "0.87.0"
+version = "0.87.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Closes #1472.

A region `aggregate` like `count(AssessmentEvent where status in [reviewed, released, analysed])` **passed `dazzle validate` but fetched 0 at runtime** — only `=` / `!=` evaluated in aggregate where-clauses. The worst kind of bug: validates clean, "0" looks plausible, ships wrong numbers to dashboards.

## Root cause

The typed `ConditionExpr → ScopePredicate` translator (`condition_to_predicate.py`) expanded a list into per-element `ColumnCheck`s but **kept the `IN` operator on each single-literal element**:

```python
# before — each child kept op=IN against ONE literal
[ColumnCheck(field=f, op=op, value=ValueRef(literal=v)) for v in values]
```

That compiled to `"status" IN %s` with a **scalar** bind — invalid Postgres SQL (`IN` needs a parenthesized list). The count fetcher swallowed the error and returned 0. The `not in` case was *also* wrongly OR-combined.

The legacy `parse_aggregate_where` never supported lists at all (`"No ... IN (...) lists"` in its own docstring), so the "matches parse_aggregate_where's behaviour" comment was wrong and this expansion had never been exercised against real SQL.

## Fix

Expand per De Morgan, with the correct per-element operator:

```
x in [a, b]     → (x = a) OR  (x = b)
x not in [a, b] → (x != a) AND (x != b)
```

`in []` compiles to `FALSE`; a single-element list collapses to one `= %s`.

This implements the issue's **preferred option (a)** — full `in` support at parity with region/list filters — so `validate` accepting it is now correct.

## Tests (TDD)

`tests/unit/test_condition_to_predicate.py` — the existing list test asserted OR-of-ColumnChecks but **never checked the op**, which is how the bug slipped through. Added:
- per-element op is `=` (`EQ`), not `IN`
- compile-level: output is `= %s` per branch, **never `IN %s`**, params bound correctly
- `not in` → AND-of-`!=`

Verified the `display: metrics` path passes the typed `ConditionExpr` straight into the fixed translator. Predicate/aggregate/condition suites (775) green; `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🔖 Claude-lens: dazzle