### PR TITLE
feat: agent self-reflection pass 2 — first-party corroboration + 2 disciplined declines (v0.87.3)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -374,4 +374,4 @@ Example: `examples/ops_dashboard` has working `bar_chart` (FK `group_by: system`
 - **KG re-seeding**: `ensure_seeded()` checks a version key; bump it in `seed.py` when TOML data changes.
 
 ---
-**Version**: 0.87.2 | **Python**: 3.12+ | **Status**: Production Ready
+**Version**: 0.87.3 | **Python**: 3.12+ | **Status**: Production Ready

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.87.3] - 2026-06-26
+
+### Changed
+- **Agent self-reflection programme — pass 2: first-party corroboration + two disciplined declines.** The two shipped agent-era counter-priors now carry **first-party evidence** from this repo's own (agent-generated, 5.5k-commit) history: `reinvented-capability` cites filed tech-debt where the prior recurred — a `slug:` primitive added because *"every multi-tenant app reimplements"* it (#1288), *"~20 inline copies"* of DB-URL normalisation consolidated (#1185), duplicate constants (#1459), persistent re-export blocks (#1439); `assert-on-mock` notes the construct's surface here (~21% of ~1,470 test files use mocks). Two further candidates were run through the reflection/steelman dialectic and **correctly declined** (the catalogue stays load-bearing): *verbosity/god-functions* (mis-specified — sub-small effect size lands on the explicit-by-design variant Dazzle prizes; convictable residue folds into `god-entities`) and *extract-without-a-frame* (Fowler's Data Clump at n=1 — drop, revisit at n=2-3). KG re-seeds (`SEED_SCHEMA_VERSION` 27→28).
+
+### Agent Guidance
+- **The programme declines as readily as it promotes — by design.** A human-flagged "AI anti-pattern" only becomes a counter-prior if it survives an adversarial steelman *and* has measured recurrence. This pass examined 4 candidates and promoted 0 new ones (the 2 real entries shipped in v0.87.2); verbosity and extract-without-a-frame were declined with recorded reasons. When proposing a new counter-prior, expect to clear the same bar: distinct from existing entries (incl. classic refactoring lore), recurrence shown (not n=1), and a defensible convict/acquit boundary — not a blanket ban.
+
 ## [0.87.2] - 2026-06-26
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # DAZZLE Development Roadmap
 
 **Last Updated**: 2026-06-16
-**Current Version**: v0.87.2
+**Current Version**: v0.87.3
 
 For past releases, see [CHANGELOG.md](CHANGELOG.md).
 

--- a/docs/counter-priors/assert-on-mock.md
+++ b/docs/counter-priors/assert-on-mock.md
@@ -101,3 +101,10 @@ that looks like new coverage is the one most likely to be hollow. The legitimate
 forms (boundary mocking, parameterised matrices with independently-derived
 expecteds, blessed snapshots) are not just allowed but encouraged; the line is
 whether a real defect can turn the test red.
+
+**First-party corroboration.** This repo's own (agent-generated) test suite shows
+the construct at scale: of ~1,470 test files, ~21% use mocks / `@patch`, with
+hundreds of `assert_called*` interaction assertions. Prevalence alone is not
+conviction — most are the legitimate forms above — but it confirms the surface
+this prior acts on is large here, which is why the discriminating question
+("would a real defect turn this red?") is the cheaper guard than auditing after.

--- a/docs/counter-priors/reinvented-capability.md
+++ b/docs/counter-priors/reinvented-capability.md
@@ -95,3 +95,12 @@ layer closes it by construction; for everything else, the fix is inference-time 
 discover before you write. A re-implemented invariant is a divergence surface that
 RBAC, scope composition, and migrations cannot see, because the framework only
 guarantees the path that goes through the framework.
+
+**First-party corroboration.** A scan of this repo's own closed issues (the
+codebase is ~entirely agent-generated, 5.5k commits) finds the prior recurring as
+filed tech-debt: a `slug:` primitive added because *"every multi-tenant Dazzle app
+reimplements"* it (#1288); *"~20 inline copies"* of DB-URL normalisation
+consolidated (#1185); duplicate `VIRTUAL_ENTITY_NAMES` (#1459); persistent
+re-export/wrapper blocks (#1439). The agent re-derived, then a later agent filed
+the consolidation — exactly the discover-before-you-write gap, paid down after the
+fact instead of avoided.

--- a/homebrew/dazzle.rb
+++ b/homebrew/dazzle.rb
@@ -10,10 +10,10 @@ class Dazzle < Formula
 
   desc "DSL-first application framework with LLM-assisted development"
   homepage "https://github.com/manwithacat/dazzle"
-  version "0.87.2"
+  version "0.87.3"
   license "MIT"
 
-  url "https://github.com/manwithacat/dazzle/archive/refs/tags/v0.87.2.tar.gz"
+  url "https://github.com/manwithacat/dazzle/archive/refs/tags/v0.87.3.tar.gz"
   sha256 "PLACEHOLDER_SOURCE_SHA256"
 
   # pydantic-core requires Rust to build from source, so use pre-built wheels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dazzle-dsl"
-version = "0.87.2"
+version = "0.87.3"
 description = "DAZZLE — declarative SaaS framework with built-in compliance (SOC 2, ISO 27001), provable RBAC, and graph features"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/dazzle/mcp/knowledge_graph/seed.py
+++ b/src/dazzle/mcp/knowledge_graph/seed.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Bump this when the mapping logic changes to trigger a re-seed
-SEED_SCHEMA_VERSION = 27  # v27: agent-era counter-priors — reinvented-capability + assert-on-mock
+SEED_SCHEMA_VERSION = 28  # v28: first-party corroboration added to agent-era counter-priors
 
 
 def compute_seed_version() -> str:

--- a/src/dazzle/mcp/semantics_kb/core.toml
+++ b/src/dazzle/mcp/semantics_kb/core.toml
@@ -3,7 +3,7 @@
 
 [meta]
 category = "Core Constructs"
-version = "0.87.2"
+version = "0.87.3"
 
 [concepts.entity]
 category = "Core Construct"

--- a/uv.lock
+++ b/uv.lock
@@ -912,7 +912,7 @@ wheels = [
 
 [[package]]
 name = "dazzle-dsl"
-version = "0.87.2"
+version = "0.87.3"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Second pass of the [agent self-reflection programme](https://github.com/manwithacat/dazzle/blob/main/docs/architecture/agent-self-reflection.md). Strengthens the two shipped agent-era counter-priors with **measured first-party evidence** from this repo's own agent-generated history, and records two further candidates the programme **correctly declined** — the catalogue stays load-bearing.

## First-party corroboration (the epoch/first-party methodology in action)

The codebase is ~entirely agent-generated (5.5k commits), so its own filed tech-debt is first-party evidence:
- **`reinvented-capability`** — a `slug:` primitive added because *"every multi-tenant Dazzle app reimplements"* it (#1288); *"~20 inline copies"* of DB-URL normalisation consolidated (#1185); duplicate constants (#1459); persistent re-export blocks (#1439). The agent re-derived; a later agent filed the consolidation — the discover-before-you-write gap, paid down after the fact.
- **`assert-on-mock`** — ~21% of ~1,470 test files use mocks, hundreds of `assert_called*` occurrences. Prevalence, not conviction (most are legitimate), but it confirms the surface is large here.

Honest limit: the issue-log epoch stratification is truncated by the 300-issue fetch window, so I present this as prevalence/recurrence, not a clean cross-epoch persistence proof.

## Two disciplined declines

Both run through an independent steelman dialectic; both correctly **did not** become entries:
- **verbosity/god-functions** — PARTIALLY CONVICTED but mis-specified. Sub-small effect (d≈0.155) lands on the *explicit-by-design* variant Dazzle prizes; convictable residue (mixed-abstraction, multi-responsibility) folds into `god-entities`. A standalone "verbosity" entry would false-positive against exactly the inspectable code we want.
- **extract-without-a-frame** — PARTIALLY CONVICTED but DROP. Convictable core is literally Fowler's Data Clump → Introduce Parameter Object; n=1, no shown recurrence. Revisit at n=2-3.

This pass examined 4 candidates and promoted **0** new ones (the 2 real entries shipped in v0.87.2). Declining is the point.

KG re-seeds (`SEED_SCHEMA_VERSION` 27→28); drift gate green. Released as **v0.87.3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🔖 Claude-lens: dazzle