### PR TITLE
docs: publish Research section (context-bounds prediction investigation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ Works with VS Code, Neovim, Emacs, and any editor supporting LSP. See [docs/refe
 - **[Enterprise SSO & Provisioning](docs/reference/enterprise-sso.md)** — per-org OIDC / SAML 2.0 / SCIM (opt-in)
 - **[Autonomous Harness](docs/autonomous-harness.md)** — Claude Code slash commands + methodology
 - **[ADRs](docs/adr/INDEX.md)** — architectural decisions, defended
+- **[Research notes](docs/research/INDEX.md)** — reproducible empirical investigations (agent-era counter-priors, predicting task context from a code graph)
 - **[Architecture](docs/architecture/)** — system design, pipeline, MCP server
 - **[Getting Started](docs/getting-started/)** — installation, quickstart, first app
 - **[Examples](examples/)** — runnable example applications

--- a/docs/architecture/agent-self-reflection.md
+++ b/docs/architecture/agent-self-reflection.md
@@ -157,3 +157,4 @@ production rather than the training corpus it inherited.
 - [Counter-prior catalogue](../counter-priors/INDEX.md) — where promoted entries land
 - [Model-driven failure modes](model-driven-failure-modes.md) — MDF-14 is the home mode; its five-question rubric is the promotion gate
 - [ADR-0027](../adr/0027-no-polymorphic-ref.md) — the four-question interrogation that is this protocol's structural ancestor
+- [Research: predicting task context from a code graph](../research/context-bounds-prediction.md) — an empirical spike motivated by this programme's "bounded context" finding

--- a/docs/research/INDEX.md
+++ b/docs/research/INDEX.md
@@ -1,0 +1,24 @@
+# Research notes
+
+Empirical investigations spun off from building Dazzle — short, reproducible
+studies of questions that came up while making an AI-collaborative software
+substrate. Each note states a question, runs a real experiment, and reports what
+held up (including what didn't, and any measurement mistakes caught along the way).
+
+## Notes
+
+- [Predicting task context from a code graph](context-bounds-prediction.md) — how
+  far a *cheap* static-graph baseline gets you at predicting which code must be in
+  an agent's context before a task. A naive keyword seed (45%) + forward closure
+  (73%) + bidirectional edges (91%), in ~50 deterministic lines — and why the
+  residual is a retrieval problem, not a graph or database problem. Runnable eval
+  scripts included.
+
+## Related
+
+- [Agent self-reflection](../architecture/agent-self-reflection.md) — the
+  programme that motivated the context-prediction study: discovering counter-priors
+  for *agentic* code production by having the agent adversarially interrogate its
+  own assumptions.
+- [Model-driven failure modes](../architecture/model-driven-failure-modes.md) — the
+  4GL/MDE/CASE failure-mode threat model these investigations operate against.

--- a/docs/research/context-bounds-prediction.md
+++ b/docs/research/context-bounds-prediction.md
@@ -1,0 +1,159 @@
+# Predicting task context from a code graph: how far does cheap get you?
+
+*An empirical investigation, June 2026.*
+
+## Abstract
+
+Agentic coding tools fail in predictable ways when the code they need isn't in
+the context window — they re-implement helpers that already exist, and edit code
+on assumptions the unloaded files would have corrected. This note asks whether a
+**pre-flight step** could predict, before a task starts, which code must be in
+context. We build a deliberately cheap baseline — a keyword seed resolver plus a
+static import-graph closure — and evaluate it on 11 real tasks reconstructed from
+this repository's git history (commit subject = task, changed files = ground
+truth). The result: a naive keyword seed finds the right file only **45%** of the
+time, a forward import closure lifts that to **73%**, and adding **bidirectional**
+edges (reverse dependents + siblings) reaches **91%** — all in ~50 lines of
+deterministic Python, microseconds per query, no new dependencies and no
+graph-native database. The remaining difficulty is not the graph: it is mapping a
+natural-language task to an entry point, which is a semantic-retrieval problem.
+
+## Motivation
+
+A companion investigation — [agent self-reflection](../architecture/agent-self-reflection.md)
+— found that the *real*, defensible failure modes of agentic code production are
+driven by **bounded context**: the agent re-derives a helper because the existing
+one isn't in its window (duplication-instead-of-reuse), or it edits against
+assumptions an unloaded file would have corrected. That suggests a structural fix:
+instead of catching these post-hoc, predict the relevant code *before* the task
+and load it on purpose. This note tests how tractable that prediction is.
+
+The problem decomposes into three sub-predictions:
+
+- **(A) Capacity** — will the relevant code fit in the window? Arithmetic, *given*
+  the relevant set.
+- **(B-i) Missing dependencies** — code the task will modify or call. A graph
+  reachability problem.
+- **(B-ii) Missing reuse candidates** — existing code the task will needlessly
+  re-derive. *Not* a closure problem — the helper you should reuse is, by
+  definition, not in your call graph. It's a capability search. Out of scope here;
+  it is the harder, higher-value half.
+
+## What the substrate already provided
+
+The host framework (Dazzle) ships a knowledge graph backed by SQLite. Two findings
+shaped the spike:
+
+- The schema **already defines** `file:` / `module:` / `class:` / `function:`
+  entity types — it anticipates code-symbol granularity — but the default seeder
+  populates only a concept/knowledge layer. The code graph was *schema-ready but
+  unpopulated*.
+- An AST indexer (`auto_populate`) already existed, extracting modules, classes,
+  functions, and import / inheritance / (basic) call edges — but wasn't run as
+  part of the standard seed.
+
+So roughly 80% of the B-i machinery existed already; the gap was running it and
+everything *around* the graph (seeding, relevance).
+
+## Method
+
+Three throwaway prototypes (all in [`scripts/`](scripts/), runnable against the
+repo):
+
+1. **Closure + capacity** (`ctx_manifest_proto.py`): given a seed module, compute
+   the first-party import closure via `ast` and estimate tokens.
+2. **Seed resolver** (`seed_plus_closure_eval.py`): index each module by its
+   path-terms and `def`/`class` names; score a task by weighted term overlap;
+   rank. Evaluate against ground truth.
+3. **Bidirectional closure** (`bidir_eval.py`): add reverse dependents and sibling
+   co-imports to the closure.
+
+**Evaluation set:** 11 real tasks from this repo's history. For each, the commit
+subject is the task description and the changed `src/**.py` files are ground
+truth. We measure *recall* — does the candidate set contain a truly-changed file?
+
+## Results
+
+### The closure explodes without a cut
+
+Full first-party import closure of three representative seed files:
+
+| Seed (task file) | depth-1 | depth-2 | full closure |
+|---|---|---|---|
+| an HTTP-runtime hub | 8 mod / 35k tok | 26 / 74k | **110 / 382k** |
+| a `core.ir` leaf | 1 / 1.4k | — | **1 / 1.4k** |
+| a pure-render module | 2 / 10k | 4 / 15k | **4 / 15k** |
+
+The hub's full closure (382k tokens) exceeds a typical context window — naive
+"take the closure" fails — but depth-2 (8–26 modules) is the sweet spot. A useful
+side effect: **closure size is a free coupling metric.** The pure render layer's
+closure is 4 modules; the HTTP hub's is 110, tracking the project's documented
+layer architecture exactly.
+
+### The recall ladder
+
+| Step | Recall | Working set |
+|---|---|---|
+| naive keyword seed (top-3) | **45%** | — |
+| + depth-2 forward closure | **73%** | ~31 modules |
+| + bidirectional (reverse + siblings) | **91%** | ~49 modules |
+
+- **Seed resolution is weak (45%)** because of a *symptom-vs-cause gap*: task words
+  describe where a feature *appears* (a "catalogue" view) but the fix lives in a
+  different layer (the orchestration that builds it).
+- **The forward closure rescues fuzzy seeds (45% → 73%)** — validating the core
+  design: *approximate seed + deterministic closure*, not exact resolution.
+- **Bidirectional closure reaches 91%.** Forward closure cannot reach a sibling
+  file that merely shares a common importer; adding direct reverse edges plus the
+  seed's siblings fixes this. It specifically recovered a real case where the
+  resolver picked a plausible sibling (`aggregate_where_parser`) but the fix was in
+  `condition_to_predicate` — reachable only via their shared importer.
+
+### What didn't work
+
+Adding content-grep to the resolver improved seed quality but blew the working set
+up to 131 modules on a hub case (the relevance cut becomes the binding constraint
+once recall rises) *and* still failed to recover the last miss. The one persistent
+failure — a task whose vocabulary genuinely doesn't point at the changed file —
+survives both keyword and content matching. That is the irreducible
+**semantic-retrieval tail**.
+
+## A note on rigour
+
+The first evaluation run reported **0%** — which was a *measurement bug* (a
+module-prefix mismatch in the ground-truth comparison), caught because the
+closures implausibly collapsed to 3 modules. The corrected numbers are above. We
+flag this deliberately: applying "does this measurement measure what I think it
+measures?" to one's own evaluation is the same discipline the companion
+self-reflection programme applies to code.
+
+## Limitations
+
+- The keyword resolver is a **lower bound** — names only, no content or embeddings;
+  a real harness using the agent's own search would beat it.
+- **n = 11**, all from one feature arc — directional, not a benchmark.
+- A commit subject already contains the fix's vocabulary, so the 45% seed figure is
+  likely **optimistic** for a genuinely fresh task.
+- Static Python call resolution is approximate under dynamic dispatch; the import
+  edges used here are reliable, the call edges less so.
+
+## Conclusion
+
+The graph half is genuinely cheap and effectively solved as a spike: **91% recall
+in ~50 lines, deterministic, microseconds, no new dependencies, no graph-native
+database** (which would buy nothing at this scale — hundreds of nodes, tiny
+closures). The binding constraints from here are both *non-graph*: a token-budget
+relevance cut on the candidate pool, and semantic seed retrieval for the last tail.
+The original question — "is this a straightforward code-graph problem?" — resolves
+to: *the graph part is; the hard part is intent → entry-point retrieval, a
+different problem wearing a graph costume.*
+
+## Reproduce
+
+```bash
+python docs/research/scripts/ctx_manifest_proto.py    # closure + capacity
+python docs/research/scripts/bidir_eval.py            # the full recall ladder
+```
+
+Scripts are self-contained (stdlib `ast` only) and derive the repo root from their
+own location.

--- a/docs/research/scripts/bidir_eval.py
+++ b/docs/research/scripts/bidir_eval.py
@@ -1,0 +1,184 @@
+"""Cheap bidirectional closure: forward deps + direct dependents + siblings.
+
+The #1472 miss (resolver picked aggregate_where_parser, truth was
+condition_to_predicate — siblings under a common importer) needs reverse edges.
+Add ONLY: direct dependents of the seed, and the seed's siblings (the direct
+forward-imports of those dependents). Bounded — no transitive reverse explosion.
+Re-measure recall vs forward-only.
+"""
+# ruff: noqa  -- illustrative research spike script; not framework code
+
+import ast
+import re
+from collections import defaultdict, deque
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3] / "src"
+STOP = set("fix feat add the for into with mode path support a an of to on in render".split())
+
+
+def terms(s):
+    out = set()
+    for p in re.split(r"[^a-zA-Z0-9]+", re.sub(r"\(#\d+\)", " ", s)):
+        for w in re.findall(r"[a-z0-9]+|[A-Z][a-z0-9]*", p):
+            w = w.lower()
+            if len(w) >= 3 and w not in STOP:
+                out.add(w)
+    return out
+
+
+def path_for(mod):
+    base = ROOT / Path(*mod.split("."))
+    for c in (base.with_suffix(".py"), base / "__init__.py"):
+        if c.exists():
+            return c
+    return None
+
+
+# ---- single pass: forward imports (resolved to modules), reverse map, symbol terms ----
+fwd = defaultdict(set)
+rev = defaultdict(set)
+index = {}
+allmods = []
+for p in ROOT.rglob("*.py"):
+    if "test" in p.name or "__pycache__" in str(p):
+        continue
+    mod = ".".join(p.relative_to(ROOT).with_suffix("").parts)
+    if mod.endswith(".__init__"):
+        mod = mod[:-9]
+    allmods.append((mod, p))
+
+for mod, p in allmods:
+    st = set()
+    raw = set()
+    try:
+        tree = ast.parse(p.read_text())
+        for n in ast.walk(tree):
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                st |= terms(n.name)
+            elif isinstance(n, ast.ImportFrom) and n.module and n.module.split(".")[0] == "dazzle":
+                raw.add(n.module)
+            elif isinstance(n, ast.Import):
+                for a in n.names:
+                    if a.name.split(".")[0] == "dazzle":
+                        raw.add(a.name)
+    except Exception:
+        pass
+    index[mod] = (terms(mod.replace(".", " ")), st)
+    for imp in raw:
+        m = imp if path_for(imp) else ".".join(imp.split(".")[:-1])
+        if path_for(m):
+            fwd[mod].add(m)
+            rev[m].add(mod)
+
+
+def fwd_closure(seed, depth=2):
+    seen = set()
+    q = deque([(seed, 0)])
+    while q:
+        m, d = q.popleft()
+        if m in seen:
+            continue
+        seen.add(m)
+        if d < depth:
+            for nb in fwd.get(m, ()):
+                q.append((nb, d + 1))
+    return seen
+
+
+def bidir(seed, depth=2):
+    base = fwd_closure(seed, depth)
+    deps = rev.get(seed, set())  # who imports the seed (direct)
+    base |= deps
+    for dep in deps:  # the seed's siblings = dep's direct forward imports
+        base |= fwd.get(dep, set())
+    return base
+
+
+def resolve(task, k=3):
+    t = terms(task)
+    scored = []
+    for mod, (pt, st) in index.items():
+        s = 3 * len(t & pt) + len(t & st)
+        if s:
+            scored.append((s, mod))
+    scored.sort(reverse=True)
+    return [m for _, m in scored[:k]]
+
+
+CASES = [
+    (
+        "catalogue line/sparkline/radar/area + single-dim area fix",
+        ["dazzle.http.runtime.workspace_region_orchestration"],
+    ),
+    (
+        "funnel_chart render path + catalogue funnel mode",
+        ["dazzle.http.runtime.workspace_region_render"],
+    ),
+    (
+        "box_plot render path + catalogue histogram/box_plot modes",
+        ["dazzle.http.runtime.workspace_region_render"],
+    ),
+    (
+        "render stored-narrative overlay prose + confidence badge",
+        ["dazzle.render.fragment.region._builders_charts"],
+    ),
+    (
+        "read stored insight into ctx provider seam + fallback",
+        [
+            "dazzle.http.runtime.workspace_region_orchestration",
+            "dazzle.http.runtime.workspace_region_render",
+            "dazzle.render.fragment.region._context",
+        ],
+    ),
+    (
+        "StoredInsight type + insight-store provider seam",
+        ["dazzle.http.runtime.insight_store", "dazzle.render.fragment.insight"],
+    ),
+    (
+        "render rag_on band-tone badge in list cells",
+        ["dazzle.render.fragment.region._builders_tables"],
+    ),
+    (
+        "rag_on orchestration band tones to ctx",
+        [
+            "dazzle.http.runtime.workspace_region_computes",
+            "dazzle.http.runtime.workspace_region_orchestration",
+            "dazzle.http.runtime.workspace_region_render",
+        ],
+    ),
+    (
+        "validate rag_on decorator E_RAG",
+        ["dazzle.core.lint", "dazzle.core.validation.ux", "dazzle.core.validator"],
+    ),
+    ("parse rag_on + tone_bands region keywords", ["dazzle.core.dsl_parser_impl.workspace"]),
+    (
+        "aggregate count where status in list silently returns 0",
+        ["dazzle.core.ir.condition_to_predicate"],
+    ),
+]
+
+fc = bc = 0
+fs = []
+bs = []
+for task, truth in CASES:
+    seeds = resolve(task, 3)
+    ts = set(truth)
+    fu = set()
+    bu = set()
+    for s in seeds:
+        fu |= fwd_closure(s, 2)
+        bu |= bidir(s, 2)
+    fh = any(m in ts for m in fu)
+    bh = any(m in ts for m in bu)
+    fc += fh
+    bc += bh
+    fs.append(len(fu))
+    bs.append(len(bu))
+    flag = "  <-- rescued by bidir" if (bh and not fh) else ""
+    print(
+        f"{task[:44]:<46} fwd:{'Y' if fh else 'n'} bidir:{'Y' if bh else 'n'}  (|f|={len(fu)} |b|={len(bu)}){flag}"
+    )
+n = len(CASES)
+print(f"\nforward closure recall:       {fc}/{n}={fc / n:.0%}  (avg {sum(fs) / n:.0f} modules)")
+print(f"bidirectional closure recall: {bc}/{n}={bc / n:.0%}  (avg {sum(bs) / n:.0f} modules)")

--- a/docs/research/scripts/ctx_manifest_proto.py
+++ b/docs/research/scripts/ctx_manifest_proto.py
@@ -1,0 +1,101 @@
+"""Throwaway prototype: B(i) dependency closure + A capacity prediction.
+
+Given a seed module, compute the first-party import closure over src/dazzle via
+AST (deterministic), estimate tokens, and report what a pre-flight 'context
+manifest' would say. Purpose: measure the ORDER empirically — does the closure
+explode? do you need a relevance cut?
+"""
+# ruff: noqa  -- illustrative research spike script; not framework code
+
+import ast
+from collections import deque
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3] / "src"
+PKG = "dazzle"
+
+
+def mod_name(p: Path) -> str:
+    rel = p.relative_to(ROOT).with_suffix("")
+    parts = list(rel.parts)
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+def path_for(mod: str) -> Path | None:
+    base = ROOT / Path(*mod.split("."))
+    for cand in (base.with_suffix(".py"), base / "__init__.py"):
+        if cand.exists():
+            return cand
+    return None
+
+
+def first_party_imports(p: Path) -> set[str]:
+    """Module names this file imports from within `dazzle` (top-level + lazy)."""
+    try:
+        tree = ast.parse(p.read_text(), filename=str(p))
+    except Exception:
+        return set()
+    out: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module and node.module.split(".")[0] == PKG:
+            out.add(node.module)
+        elif isinstance(node, ast.Import):
+            for a in node.names:
+                if a.name.split(".")[0] == PKG:
+                    out.add(a.name)
+    return out
+
+
+def tokens(p: Path) -> int:
+    try:
+        return len(p.read_text()) // 4  # ~4 chars/token heuristic
+    except Exception:
+        return 0
+
+
+def closure(seed_mod: str, max_depth: int):
+    """BFS forward import closure with depth tracking."""
+    seen: dict[str, int] = {}
+    q = deque([(seed_mod, 0)])
+    while q:
+        mod, d = q.popleft()
+        if mod in seen and seen[mod] <= d:
+            continue
+        seen[mod] = d
+        if d >= max_depth:
+            continue
+        p = path_for(mod)
+        if not p:
+            continue
+        for imp in first_party_imports(p):
+            # normalize: an import of dazzle.x.y might be a symbol in dazzle.x
+            m = imp
+            if not path_for(m):
+                m = ".".join(imp.split(".")[:-1])
+            if path_for(m):
+                q.append((m, d + 1))
+    return seen
+
+
+def report(seed_mod: str):
+    p = path_for(seed_mod)
+    if not p:
+        print(f"seed {seed_mod} not found")
+        return
+    print(f"\n{'=' * 70}\nSEED: {seed_mod}  ({tokens(p)} tok)")
+    for depth in (1, 2, 3, 999):
+        seen = closure(seed_mod, depth)
+        mods = [m for m in seen if path_for(m)]
+        tot = sum(tokens(path_for(m)) for m in mods if path_for(m))
+        label = f"depth {depth}" if depth != 999 else "full closure"
+        print(f"  {label:>13}: {len(mods):>4} modules, ~{tot:>7,} tokens")
+
+
+for seed in [
+    "dazzle.http.runtime.workspace_region_render",  # the file from the #1473 task
+    "dazzle.core.ir.condition_to_predicate",  # the #1472 fix file
+    "dazzle.render.svg",  # the multi-series SVG file
+]:
+    report(seed)

--- a/docs/research/scripts/seed_plus_closure_eval.py
+++ b/docs/research/scripts/seed_plus_closure_eval.py
@@ -1,0 +1,162 @@
+"""Does the depth-2 closure rescue a fuzzy seed?
+
+For each case: resolver -> top-3 seed modules -> union of their depth-2 import
+closures -> does it contain a ground-truth module? This tests the real design:
+approximate seed + deterministic closure, not exact seed resolution.
+"""
+# ruff: noqa  -- illustrative research spike script; not framework code
+
+import ast
+import re
+from collections import deque
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3] / "src"
+STOP = set("fix feat add the for into with mode path support a an of to on in render".split())
+
+
+def terms(s):
+    s = re.sub(r"\(#\d+\)", " ", s)
+    out = set()
+    for p in re.split(r"[^a-zA-Z0-9]+", s):
+        for w in re.findall(r"[a-z0-9]+|[A-Z][a-z0-9]*", p):
+            w = w.lower()
+            if len(w) >= 3 and w not in STOP:
+                out.add(w)
+    return out
+
+
+def path_for(mod):
+    base = ROOT / Path(*mod.split("."))
+    for c in (base.with_suffix(".py"), base / "__init__.py"):
+        if c.exists():
+            return c
+    return None
+
+
+def fp_imports(p):
+    try:
+        tree = ast.parse(p.read_text())
+    except Exception:
+        return set()
+    out = set()
+    for n in ast.walk(tree):
+        if isinstance(n, ast.ImportFrom) and n.module and n.module.split(".")[0] == "dazzle":
+            out.add(n.module)
+        elif isinstance(n, ast.Import):
+            for a in n.names:
+                if a.name.split(".")[0] == "dazzle":
+                    out.add(a.name)
+    return out
+
+
+def closure(seed, depth=2):
+    seen = set()
+    q = deque([(seed, 0)])
+    while q:
+        m, d = q.popleft()
+        if m in seen:
+            continue
+        seen.add(m)
+        if d >= depth:
+            continue
+        p = path_for(m)
+        if not p:
+            continue
+        for imp in fp_imports(p):
+            mm = imp if path_for(imp) else ".".join(imp.split(".")[:-1])
+            if path_for(mm):
+                q.append((mm, d + 1))
+    return seen
+
+
+# index
+index = {}
+for p in ROOT.rglob("*.py"):
+    if "test" in p.name or "__pycache__" in str(p):
+        continue
+    mod = ".".join(p.relative_to(ROOT).with_suffix("").parts)
+    if mod.endswith(".__init__"):
+        mod = mod[:-9]
+    st = set()
+    try:
+        for n in ast.walk(ast.parse(p.read_text())):
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                st |= terms(n.name)
+    except Exception:
+        pass
+    index[mod] = (terms(mod.replace(".", " ")), st)
+
+
+def resolve(task, k=3):
+    t = terms(task)
+    scored = []
+    for mod, (pt, st) in index.items():
+        s = 3 * len(t & pt) + len(t & st)
+        if s:
+            scored.append((s, mod))
+    scored.sort(reverse=True)
+    return [m for _, m in scored[:k]]
+
+
+CASES = [
+    (
+        "catalogue line/sparkline/radar/area + single-dim area fix",
+        ["http.runtime.workspace_region_orchestration"],
+    ),
+    ("funnel_chart render path + catalogue funnel mode", ["http.runtime.workspace_region_render"]),
+    (
+        "box_plot render path + catalogue histogram/box_plot modes",
+        ["http.runtime.workspace_region_render"],
+    ),
+    (
+        "render stored-narrative overlay prose + confidence badge",
+        ["render.fragment.region._builders_charts"],
+    ),
+    (
+        "read stored insight into ctx provider seam + fallback",
+        [
+            "http.runtime.workspace_region_orchestration",
+            "http.runtime.workspace_region_render",
+            "render.fragment.region._context",
+        ],
+    ),
+    (
+        "StoredInsight type + insight-store provider seam",
+        ["http.runtime.insight_store", "render.fragment.insight"],
+    ),
+    ("render rag_on band-tone badge in list cells", ["render.fragment.region._builders_tables"]),
+    (
+        "rag_on orchestration band tones to ctx",
+        [
+            "http.runtime.workspace_region_computes",
+            "http.runtime.workspace_region_orchestration",
+            "http.runtime.workspace_region_render",
+        ],
+    ),
+    ("validate rag_on decorator E_RAG", ["core.lint", "core.validation.ux", "core.validator"]),
+    ("parse rag_on + tone_bands region keywords", ["core.dsl_parser_impl.workspace"]),
+    ("aggregate count where status in list silently returns 0", ["core.ir.condition_to_predicate"]),
+]
+
+seed_hit = clos_hit = 0
+sizes = []
+for task, truth in CASES:
+    seeds = resolve(task, 3)
+    ts = set("dazzle." + t for t in truth)
+    sh = any(s in ts for s in seeds)
+    union = set()
+    for s in seeds:
+        union |= closure(s, 2)
+    ch = any(m in ts for m in union)
+    sizes.append(len(union))
+    seed_hit += sh
+    clos_hit += ch
+    print(
+        f"{task[:48]:<50} seed-hit:{'Y' if sh else 'n'}  closure-hit:{'Y' if ch else 'n'}  (|closure|={len(union)})"
+    )
+n = len(CASES)
+print(
+    f"\ntop-3 seed recall: {seed_hit}/{n}={seed_hit / n:.0%}   +depth-2 closure recall: {clos_hit}/{n}={clos_hit / n:.0%}"
+)
+print(f"avg closure size (modules): {sum(sizes) / n:.0f}")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,9 @@ nav:
       - Model-Driven Failure Modes: architecture/model-driven-failure-modes.md
       - Agent Self-Reflection: architecture/agent-self-reflection.md
       - Project Evolution: architecture/evolution.md
+  - Research:
+      - Overview: research/INDEX.md
+      - Context-Bounds Prediction: research/context-bounds-prediction.md
   - DSL Reference:
       - Overview: reference/index.md
       - Entities: reference/entities.md


### PR DESCRIPTION
## Summary

Publishes a **Research** section to the docs site — reproducible empirical investigations spun off from building Dazzle. First note: *Predicting task context from a code graph.*

The investigation asks how far a deliberately **cheap** static-graph baseline gets at predicting which code must be in an agent's context before a task starts (motivated by the [agent self-reflection](https://github.com/manwithacat/dazzle/blob/main/docs/architecture/agent-self-reflection.md) finding that bounded context drives the real agent-era failure modes). Result, on 11 real tasks reconstructed from git history:

| Step | Recall |
|---|---|
| naive keyword seed (top-3) | 45% |
| + forward import closure | 73% |
| + bidirectional (reverse + siblings) | **91%** |

~50 lines of deterministic Python, microseconds per query, no new deps, no graph-native DB — and the conclusion that the residual is a *semantic-retrieval* problem, not a graph or database one.

Includes:
- `docs/research/context-bounds-prediction.md` — the note, with method, the recall ladder, an honest measurement-bug disclosure, and limitations.
- `docs/research/scripts/` — three runnable eval scripts (stdlib `ast` only; derive repo root from their own location).
- New Research section in the mkdocs nav + a README link; cross-linked from the agent self-reflection programme.

Docs-only — no version bump, no release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🔖 Claude-lens: dazzle