### PR TITLE
docs(research): reuse-detection study — cheap clone detector / B(ii) feasibility

### DIFF
--- a/docs/counter-priors/reinvented-capability.md
+++ b/docs/counter-priors/reinvented-capability.md
@@ -103,4 +103,7 @@ reimplements"* it (#1288); *"~20 inline copies"* of DB-URL normalisation
 consolidated (#1185); duplicate `VIRTUAL_ENTITY_NAMES` (#1459); persistent
 re-export/wrapper blocks (#1439). The agent re-derived, then a later agent filed
 the consolidation — exactly the discover-before-you-write gap, paid down after the
-fact instead of avoided.
+fact instead of avoided. A quantified scan —
+[Can a cheap detector catch re-implemented capability before it's written?](../research/reuse-detection.md)
+— finds 3.2% of functions in near-duplicate clusters, including clean cases like one
+availability check re-implemented across four files.

--- a/docs/research/INDEX.md
+++ b/docs/research/INDEX.md
@@ -19,6 +19,12 @@ held up (including what didn't, and any measurement mistakes caught along the wa
   disciplined-rise / campaign-noise) and the finding that no measured construct
   worsens with newer models — including a rising-`noqa` regression that *acquits*
   under the same convict/acquit discipline the reflection programme uses on code.
+- [Can a cheap detector catch re-implemented capability before it's written?](reuse-detection.md)
+  — a ~70-line Type-2 clone detector over the project's own agent-generated code.
+  3.2% of functions sit in near-duplicate clusters, including genuine re-derived
+  capability (one availability check re-implemented in four files) — but also
+  parallel-by-design families, so the cheap reuse check is a *screen, not a
+  verdict*. Tests the B(ii) reuse half the context-bounds spike left open.
 
 ## Related
 

--- a/docs/research/reuse-detection.md
+++ b/docs/research/reuse-detection.md
@@ -1,0 +1,141 @@
+# Can a cheap detector catch re-implemented capability before it's written?
+
+*An empirical investigation, June 2026.*
+
+## Abstract
+
+The strongest measured agent-production bias is **duplication-instead-of-reuse** —
+an agent re-implements a helper that already exists because its context window
+didn't contain it. We ship a counter-prior for it
+([`reinvented-capability`](../counter-priors/reinvented-capability.md)), whose fix
+is "search before you write." This note asks whether that search can be *automated
+cheaply*: a Type-2 clone detector over the project's own (agent-generated) code. The
+answer is yes-with-a-caveat. A ~70-line AST detector finds that **3.2% of functions
+(220 of 6,827) sit in near-duplicate clusters**, and the clusters include genuine
+re-implemented capability — four separate files each re-deriving "try to import X,
+return a bool"; a baseline-diff helper copied five times; a DB-init routine copied
+across three stores. But the same detector also flags *parallel-by-design* families
+(CLI sub-commands, route handlers) where the duplication is a judgment call. So a
+cheap reuse check is feasible and finds real signal — but it is a **screen, not a
+verdict**: it needs the same convict/acquit pass every other part of this programme
+requires.
+
+## Motivation
+
+The [context-bounds spike](context-bounds-prediction.md) deliberately left one half
+of the context problem untouched: **B(ii), missing reuse candidates.** Unlike
+missing dependencies, the helper you should reuse is *not* in your call graph — if
+it were, you'd already call it. It's a capability search, and the
+[`reinvented-capability`](../counter-priors/reinvented-capability.md) counter-prior
+prescribes running it "before you write." This note tests whether that search is
+cheap enough to automate, by measuring how much re-implemented capability already
+exists in this codebase and whether a trivial detector finds it.
+
+## Method
+
+[`clone_detect.py`](scripts/clone_detect.py) parses every function in `src/dazzle`
+and builds a **structural signature**: it blanks local names, arguments, and
+literals (keeping only their *type*) but retains the control-flow shape and the
+called method / keyword names — the "API skeleton." Two functions sharing a
+signature are Type-2 clones: the same logic with renamed locals. Functions are
+clustered by signature; clusters of size ≥ 2 (and ≥ 5 statements, to skip trivial
+stubs) are reported.
+
+The pre-write-check framing is the key one: this index, *queried with the signature
+of a function the agent is about to write*, answers "does this already exist?" — the
+counter-prior's discriminating question, automated.
+
+## Results
+
+| metric | value |
+|---|---|
+| functions analysed (≥ 5 statements) | 6,827 |
+| near-duplicate clusters (size ≥ 2) | 99 |
+| functions in a clone cluster | 220 (**3.2%**) |
+
+For comparison, a peer-reviewed 2025 study (FSE) measured Type-1/2 clone rates up to
+7.50% in commercial AI generators; this codebase's 3.2% is lower — consistent with
+its refactoring discipline and prior dedup campaigns — but non-trivial and real.
+
+### Convict: genuine re-implemented capability
+
+The clusters include textbook `reinvented-capability` — the same capability
+re-derived across *unrelated* modules, where a shared helper was warranted:
+
+- **"is this dependency installed?"** — `_check_matplotlib_available`,
+  `_check_networkx`, `_check_pptx_available`, `is_available`: four files each
+  re-implementing `try: import X; return True; except: return False`. The poster
+  child — one helper, re-derived four times.
+- **`diff_against_baseline` × 5** across the five `api_surface/` modules — the same
+  diff routine copied per baseline instead of parameterised once.
+- **`_init_db` / `init_db` × 4** across `token_store`, `otp_store`,
+  `recovery_codes` — the same store-init pattern re-typed per store.
+
+### Acquit: parallel-by-design families
+
+The same detector also clusters functions whose duplication is a *judgment call*,
+not a defect:
+
+- CLI sub-commands (`pulse_run`, `pulse_radar`, `pulse_timeline`) — thin parallel
+  dispatchers; a family, by design.
+- Route handlers (`serve_terms_page`, `serve_privacy_page`) — parallel by intent.
+
+These are exactly the cases the [`reinvented-capability`](../counter-priors/reinvented-capability.md)
+acquittal anticipates: structural similarity is not invariant-equivalence. Whether a
+cluster of parallel handlers *should* be one parameterised function is a real design
+question — sometimes yes, often no.
+
+### The pattern, again
+
+A crude structural-clone count *flags*; a principled distinction — "is this one
+capability re-derived, or parallel instances of a family?" — *acquits* a portion.
+This is the fourth time this programme has landed on the same shape (premature
+abstraction, tautological tests, rising-`noqa`, and now clone-rate). A reuse check
+that reported raw clone hits would cry wolf on every CLI command; the value is in the
+screen plus the discriminating question, not the screen alone.
+
+## Feasibility of the pre-write check
+
+Affirmative, with the caveat above. The signal is real (the availability-check
+cluster is a clean catch a cheap index would have surfaced *before* the fourth copy
+was written), the engine is ~70 lines of stdlib `ast`, and the false positives are a
+bounded, characterisable class (parallel families) that the convict/acquit prompt
+handles. A practical B(ii) check is: at the moment an agent is about to emit a
+function, compute its signature, query the index, and if it collides with existing
+functions, surface them and ask the discriminating question. Note this is
+*structural*, so it catches re-derivation even when the agent picked different
+names — precisely the bounded-context failure mode.
+
+## Limitations
+
+- **Type-2 only.** Exact structural signatures miss Type-3 (modified) clones, so
+  3.2% is a **lower bound**; near-duplicates with small edits are invisible here.
+  MinHash/LSH would extend to Type-3 at more cost.
+- **Already-consolidated duplication doesn't appear.** The project's prior dedup
+  campaigns removed cases like the "~20 inline copies" of one helper; this measures
+  the *residual* not-yet-caught debt, not the historical total.
+- **Structural identity ≠ semantic identity.** The signature keeps method names but
+  blanks locals/literals; two functions with the same skeleton can do genuinely
+  different things (a source of the parallel-family false positives).
+- **One codebase, one substrate.** A within-project measurement, not a claim about
+  agentic coding at large.
+
+## Conclusion
+
+Automating the `reinvented-capability` search is cheap and works: a trivial Type-2
+clone detector surfaces genuine re-implemented capability in this codebase's own
+agent-generated code (3.2% of functions in clone clusters, with clean catches like
+four copies of one availability check), and the same index queried pre-write is a
+viable B(ii) reuse guard. The catch is the recurring one: it is a *screen* that must
+be paired with the convict/acquit distinction between re-derived capability and
+parallel-by-design families — without that, it over-reports. Cheap detection of the
+duplication prior is feasible; cheap *judgement* about it is not — which is exactly
+why the counter-prior is a reflection prompt, not a lint rule.
+
+## Reproduce
+
+```bash
+python docs/research/scripts/clone_detect.py
+```
+
+Self-contained (stdlib `ast` only); derives the repo root from its own location.

--- a/docs/research/scripts/clone_detect.py
+++ b/docs/research/scripts/clone_detect.py
@@ -1,0 +1,85 @@
+"""Cheap near-duplicate function detector (the B(ii) reuse-feasibility spike).
+
+For every function in src/dazzle, build a structural signature that blanks local
+names / args / literals but keeps the *shape* plus the called-method and keyword
+names (the API skeleton). Functions sharing a signature are Type-2 clones —
+re-implemented capability. Measure the duplication rate and show the clusters.
+
+The same index, queried with an about-to-be-written function's signature, is the
+pre-write 'does this already exist?' check (the reinvented-capability counter-prior,
+automated).
+
+Run: python docs/research/scripts/clone_detect.py   (stdlib only; portable root)
+"""
+
+# ruff: noqa  -- illustrative research spike script; not framework code
+import ast
+import hashlib
+from collections import defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3] / "src" / "dazzle"
+MIN_STMTS = 5  # skip trivial stubs / properties
+
+
+def signature(fn):
+    """Structural token stream: node types + API names; local identifiers blanked."""
+    toks = []
+
+    def emit(node):
+        if isinstance(node, ast.Name):
+            toks.append("N")
+            return
+        if isinstance(node, ast.arg):
+            toks.append("A")
+            return
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            toks.append("DEF")  # blank the def name
+        elif isinstance(node, ast.Attribute):
+            toks.append(f"AT:{node.attr}")  # keep method/attr name (API surface)
+        elif isinstance(node, ast.Constant):
+            toks.append(f"C:{type(node.value).__name__}")  # literal -> its type
+        elif isinstance(node, ast.keyword):
+            toks.append(f"K:{node.arg}")
+        else:
+            toks.append(type(node).__name__)
+        for child in ast.iter_child_nodes(node):
+            emit(child)
+
+    for stmt in getattr(fn, "body", []):  # signature over the body only
+        emit(stmt)
+    return hashlib.md5("|".join(toks).encode()).hexdigest()
+
+
+functions = []
+for p in ROOT.rglob("*.py"):
+    if "test" in p.name or "/examples/" in str(p) or "__pycache__" in str(p):
+        continue
+    try:
+        tree = ast.parse(p.read_text())
+    except Exception:
+        continue
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            n = sum(1 for x in ast.walk(node) if isinstance(x, ast.stmt)) - 1
+            if n >= MIN_STMTS:
+                functions.append(
+                    (signature(node), node.name, f"{p.relative_to(ROOT.parent)}:{node.lineno}", n)
+                )
+
+clusters = defaultdict(list)
+for sig, name, loc, n in functions:
+    clusters[sig].append((name, loc, n))
+dup = {k: v for k, v in clusters.items() if len(v) >= 2}
+in_clusters = sum(len(v) for v in dup.values())
+total = len(functions)
+
+print(f"functions analysed (>= {MIN_STMTS} stmts): {total}")
+print(f"near-duplicate clusters (size >= 2):       {len(dup)}")
+print(f"functions in a clone cluster:              {in_clusters}  ({in_clusters / total:.1%})\n")
+print("Largest clusters:")
+for sig, members in sorted(dup.items(), key=lambda kv: -len(kv[1]))[:12]:
+    names = sorted({m[0] for m in members})
+    print(f"  x{len(members):>2}  names={names[:5]}{' ...' if len(names) > 5 else ''}")
+    for name, loc, n in members[:2]:
+        print(f"        {loc}")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
       - Overview: research/INDEX.md
       - Context-Bounds Prediction: research/context-bounds-prediction.md
       - Epoch Stratification: research/epoch-stratification.md
+      - Reuse Detection: research/reuse-detection.md
   - DSL Reference:
       - Overview: reference/index.md
       - Entities: reference/entities.md


### PR DESCRIPTION
## Summary

Third research note. Tests the **B(ii) (missing reuse candidates)** half of the context problem that the [context-bounds spike](https://github.com/manwithacat/dazzle/blob/main/docs/research/context-bounds-prediction.md) left open, and quantifies the [`reinvented-capability`](https://github.com/manwithacat/dazzle/blob/main/docs/counter-priors/reinvented-capability.md) counter-prior first-party.

A ~70-line Type-2 clone detector (AST structural signatures: blank locals/literals, keep the API skeleton) over `src/dazzle`:

| metric | value |
|---|---|
| functions analysed (≥5 stmts) | 6,827 |
| near-duplicate clusters | 99 |
| functions in a clone cluster | 220 (**3.2%**) |

**Convict** — genuine re-derived capability: `_check_matplotlib_available` / `_check_networkx` / `_check_pptx_available` / `is_available` (four files each re-implementing "try import X, return bool"); `diff_against_baseline` ×5; `_init_db` ×4 across three stores.

**Acquit** — parallel-by-design families: CLI sub-commands, route handlers, where the duplication is a judgment call.

So a cheap reuse check is feasible and finds real signal — the same index queried *pre-write* is the automated "does this already exist?" check — but it's a **screen, not a verdict**: it needs the convict/acquit distinction between re-derived capability and parallel families. That's the fourth time this programme lands on the same shape (premature abstraction, tautological tests, rising-`noqa`, now clone-rate).

Honest limits: Type-2 only (3.2% is a lower bound); already-consolidated dedup doesn't appear (residual debt only); structural ≠ semantic identity; single-codebase.

Docs-only — no version bump, no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🔖 Claude-lens: dazzle