### PR TITLE
feat: clone ratchet — reinvented-capability layer-3 filter (v0.87.4)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -374,4 +374,4 @@ Example: `examples/ops_dashboard` has working `bar_chart` (FK `group_by: system`
 - **KG re-seeding**: `ensure_seeded()` checks a version key; bump it in `seed.py` when TOML data changes.
 
 ---
-**Version**: 0.87.3 | **Python**: 3.12+ | **Status**: Production Ready
+**Version**: 0.87.4 | **Python**: 3.12+ | **Status**: Production Ready

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.87.4] - 2026-06-26
+
+### Added
+- **Clone ratchet — the `reinvented-capability` counter-prior's layer-3 filter.** `dazzle fitness clones` detects Type-2 function clones (structural signature: argument arity + control-flow shape + called-method/keyword names, modulo local names and literal values), and a new ratchet gate (`tests/unit/test_clone_ratchet.py`, baseline `tests/unit/fixtures/clone_baseline.json` — 99 clusters / 220 functions) fails the build on a *new* or *grown* duplicate cluster. This completes the three-layer coverage (grammar / inference / filter) for the duplication-instead-of-reuse prior, which previously had only the inference-layer reflection prompt. Grew out of the [reuse-detection research note](docs/research/reuse-detection.md). The ratchet is **keyed on the signature, not on function names**, so renaming or moving an already-clustered function does not trip it — only genuine new duplication does.
+
+### Agent Guidance
+- **New build gate: the clone ratchet.** Before hand-writing a function, prefer reusing an existing one; the gate forbids adding a *new* structural duplicate of code that already exists. If a flagged cluster is genuinely parallel-by-design accepted residue (a family of CLI sub-commands / route handlers), regenerate the baseline with `dazzle fitness clones --write-baseline` (mirrors the complexity-ratchet escape hatch). A pure rename/move never trips it (signature-keyed). `dazzle fitness clones` (report-only) lists current clusters — query it when about to write a helper, as the automated form of `reinvented-capability`'s "does this already exist?" question.
+
 ## [0.87.3] - 2026-06-26
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # DAZZLE Development Roadmap
 
 **Last Updated**: 2026-06-16
-**Current Version**: v0.87.3
+**Current Version**: v0.87.4
 
 For past releases, see [CHANGELOG.md](CHANGELOG.md).
 

--- a/docs/counter-priors/reinvented-capability.md
+++ b/docs/counter-priors/reinvented-capability.md
@@ -25,7 +25,8 @@ refs:
   adrs: []
   memories: []
   pr_review_agents: []
-  tests: []
+  tests:
+    - tests/unit/test_clone_ratchet.py
 detectors: []
 ---
 
@@ -92,7 +93,10 @@ are each "the agent re-implemented a capability the framework already provides."
 Those are first-party evidence that this prior recurs in Dazzle's own
 agent-generated history. Where a specific capability has a keyword, the **grammar**
 layer closes it by construction; for everything else, the fix is inference-time —
-discover before you write. A re-implemented invariant is a divergence surface that
+discover before you write — backed by a **filter** layer: `dazzle fitness clones`
+detects Type-2 structural re-derivation, and the clone ratchet
+(`tests/unit/test_clone_ratchet.py`) fails the build on a *new* duplicated cluster.
+All three substrate layers now cover this prior. A re-implemented invariant is a divergence surface that
 RBAC, scope composition, and migrations cannot see, because the framework only
 guarantees the path that goes through the framework.
 

--- a/docs/research/reuse-detection.md
+++ b/docs/research/reuse-detection.md
@@ -102,7 +102,11 @@ was written), the engine is ~70 lines of stdlib `ast`, and the false positives a
 bounded, characterisable class (parallel families) that the convict/acquit prompt
 handles. A practical B(ii) check is: at the moment an agent is about to emit a
 function, compute its signature, query the index, and if it collides with existing
-functions, surface them and ask the discriminating question. Note this is
+functions, surface them and ask the discriminating question. **This has since been
+shipped** as the `reinvented-capability` counter-prior's filter layer — `dazzle
+fitness clones` plus a ratchet gate (`tests/unit/test_clone_ratchet.py`) that fails
+the build on a *new* duplicated cluster while grandfathering the parallel-by-design
+families as accepted residue. Note this is
 *structural*, so it catches re-derivation even when the agent picked different
 names — precisely the bounded-context failure mode.
 

--- a/homebrew/dazzle.rb
+++ b/homebrew/dazzle.rb
@@ -10,10 +10,10 @@ class Dazzle < Formula
 
   desc "DSL-first application framework with LLM-assisted development"
   homepage "https://github.com/manwithacat/dazzle"
-  version "0.87.3"
+  version "0.87.4"
   license "MIT"
 
-  url "https://github.com/manwithacat/dazzle/archive/refs/tags/v0.87.3.tar.gz"
+  url "https://github.com/manwithacat/dazzle/archive/refs/tags/v0.87.4.tar.gz"
   sha256 "PLACEHOLDER_SOURCE_SHA256"
 
   # pydantic-core requires Rust to build from source, so use pre-built wheels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dazzle-dsl"
-version = "0.87.3"
+version = "0.87.4"
 description = "DAZZLE — declarative SaaS framework with built-in compliance (SOC 2, ISO 27001), provable RBAC, and graph features"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/dazzle/cli/fitness.py
+++ b/src/dazzle/cli/fitness.py
@@ -17,6 +17,7 @@ import typer
 
 from dazzle.core.model_defaults import DEFAULT_JUDGMENT_MODEL
 from dazzle.fitness.backlog import read_backlog
+from dazzle.fitness.clones import build_clone_baseline, compute_clone_index
 from dazzle.fitness.triage import (
     cluster_findings,
     read_queue_file,
@@ -340,10 +341,6 @@ def clones_command(
     parallel-by-design (a family of CLI commands / route handlers) is accepted
     residue — it lives in the baseline; the gate only forbids *new* duplication.
     """
-    import json
-
-    from dazzle.fitness.clones import build_clone_baseline, compute_clone_index
-
     repo = project or Path.cwd()
     root = repo / "src" / "dazzle"
 

--- a/src/dazzle/cli/fitness.py
+++ b/src/dazzle/cli/fitness.py
@@ -277,6 +277,7 @@ def _build_llm_client(model: str | None, dry_run: bool) -> object:
 
 
 _COMPLEXITY_BASELINE = Path("tests/unit/fixtures/complexity_baseline.json")
+_CLONE_BASELINE = Path("tests/unit/fixtures/clone_baseline.json")
 
 
 @fitness_app.command("code")
@@ -322,3 +323,44 @@ def code_command(
         typer.echo(f"Wrote {out}")
     else:
         typer.echo(md)
+
+
+@fitness_app.command("clones")
+def clones_command(
+    project: Path | None = typer.Option(None, "--project", help="Repo root (default: cwd)"),
+    write_baseline: bool = typer.Option(
+        False, "--write-baseline", help="Regenerate the clone (reuse) ratchet baseline"
+    ),
+) -> None:
+    """Type-2 function-clone detection — the reinvented-capability layer-3 filter.
+
+    Reports clusters of functions sharing a structural signature (re-implemented
+    capability). Report-only by default; `--write-baseline` re-tightens the clone
+    ratchet (`tests/unit/test_clone_ratchet.py`) after a dedup. A cluster that is
+    parallel-by-design (a family of CLI commands / route handlers) is accepted
+    residue — it lives in the baseline; the gate only forbids *new* duplication.
+    """
+    import json
+
+    from dazzle.fitness.clones import build_clone_baseline, compute_clone_index
+
+    repo = project or Path.cwd()
+    root = repo / "src" / "dazzle"
+
+    if write_baseline:
+        baseline = build_clone_baseline(root)
+        out = repo / _CLONE_BASELINE
+        out.write_text(json.dumps(baseline, indent=2) + "\n")
+        members = sum(int(e["count"]) for e in baseline)
+        typer.echo(f"Wrote {out} ({len(baseline)} clusters, {members} functions)")
+        return
+
+    index = compute_clone_index(root)
+    members = sum(len(m) for m in index.values())
+    typer.echo(f"# Re-implemented capability — {len(index)} clone clusters, {members} functions\n")
+    for cluster in sorted(index.values(), key=len, reverse=True):
+        typer.echo(f"x{len(cluster)}:")
+        for member in cluster:
+            typer.echo(f"    {member}")
+    if not index:
+        typer.echo("No clone clusters found.")

--- a/src/dazzle/fitness/clones.py
+++ b/src/dazzle/fitness/clones.py
@@ -98,7 +98,7 @@ def _signature(fn: ast.AST) -> str:
 
     for stmt in getattr(fn, "body", []):
         emit(stmt)
-    return hashlib.md5("|".join(toks).encode()).hexdigest()  # noqa: S324 — non-crypto bucketing
+    return hashlib.md5("|".join(toks).encode(), usedforsecurity=False).hexdigest()
 
 
 def _stmt_count(fn: ast.AST) -> int:

--- a/src/dazzle/fitness/clones.py
+++ b/src/dazzle/fitness/clones.py
@@ -1,0 +1,171 @@
+"""Framework structural-fitness: Type-2 function-clone detection.
+
+The **layer-3 filter** for the ``reinvented-capability`` counter-prior
+(``docs/counter-priors/reinvented-capability.md``). Two functions are a Type-2
+clone when they share a *structural signature* — the same argument arity, the same
+control-flow shape, and the same called-method / keyword names, modulo local
+identifier names and literal values. A cluster of such functions is re-implemented
+capability: the same logic typed more than once, the duplication agentic
+production over-produces because the existing copy wasn't in the context window.
+
+``compute_clone_index`` finds the clusters keyed by signature;
+``build_clone_baseline`` freezes the accepted set; ``compare_clones`` flags a
+*new* or *grown* cluster. The committed baseline feeds
+``tests/unit/test_clone_ratchet.py`` (the duplication creep gate), mirroring the
+complexity ratchet in :mod:`dazzle.fitness.code`.
+
+The ratchet is keyed on the **signature**, not on function names, so a rename or
+file-move of an already-clustered function does NOT trip it (the structure is
+unchanged) — only genuine new duplication does. A cluster that is
+parallel-by-design (a family of CLI sub-commands, route handlers) rather than a
+single capability re-derived is *accepted residue*; it lives in the baseline and
+the gate only forbids growth beyond it.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+#: Functions with fewer statements than this are skipped — trivial stubs,
+#: properties, and one-liners cluster spuriously and carry no reuse signal.
+MIN_STMTS = 5
+
+
+def _py_files(root: Path) -> list[Path]:
+    """Framework .py files under ``root``, excluding tests, examples, caches.
+
+    The test exclusion is anchored (``test_*`` / a ``tests/`` dir) so production
+    modules whose name merely contains "test" — ``testing/``, ``test_design.py``,
+    ``*_test_generator.py`` — are *covered*, not silently skipped.
+    """
+    out: list[Path] = []
+    for p in sorted(root.rglob("*.py")):
+        s = str(p)
+        if p.name.startswith("test_") or "/tests/" in s:
+            continue
+        if "/examples/" in s or "__pycache__" in s:
+            continue
+        out.append(p)
+    return out
+
+
+def _arg_arity(fn: ast.AST) -> int:
+    args = getattr(fn, "args", None)
+    if args is None:
+        return 0
+    return (
+        len(getattr(args, "posonlyargs", []))
+        + len(args.args)
+        + len(args.kwonlyargs)
+        + (1 if args.vararg else 0)
+        + (1 if args.kwarg else 0)
+    )
+
+
+def _signature(fn: ast.AST) -> str:
+    """Structural token stream of a function: arg arity + body shape + API names.
+
+    Blanks local names (``ast.Name`` → ``N``), arguments (``A``), and literals
+    (kept as their *type*), but retains the argument arity, the node-type shape,
+    and the called method / keyword names — the "API skeleton". Two functions with
+    the same signature differ only in local names and literal values.
+    """
+    toks: list[str] = [f"ARITY:{_arg_arity(fn)}"]
+
+    def emit(node: ast.AST) -> None:
+        if isinstance(node, ast.Name):
+            toks.append("N")
+            return
+        if isinstance(node, ast.arg):
+            toks.append("A")
+            return
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            toks.append("DEF")  # blank the def name
+        elif isinstance(node, ast.Attribute):
+            toks.append(f"AT:{node.attr}")  # keep method/attr name (API surface)
+        elif isinstance(node, ast.Constant):
+            toks.append(f"C:{type(node.value).__name__}")  # literal → its type
+        elif isinstance(node, ast.keyword):
+            toks.append(f"K:{node.arg}")
+        else:
+            toks.append(type(node).__name__)
+        for child in ast.iter_child_nodes(node):
+            emit(child)
+
+    for stmt in getattr(fn, "body", []):
+        emit(stmt)
+    return hashlib.md5("|".join(toks).encode()).hexdigest()  # noqa: S324 — non-crypto bucketing
+
+
+def _stmt_count(fn: ast.AST) -> int:
+    return sum(1 for x in ast.walk(fn) if isinstance(x, ast.stmt)) - 1
+
+
+def compute_clone_index(root: Path, min_stmts: int = MIN_STMTS) -> dict[str, list[str]]:
+    """Map each Type-2 clone signature to its members under ``root``.
+
+    Members are stable identities ``"<relpath>::<funcname>"`` (no line numbers).
+    Only signatures with ≥ 2 distinct members (a clone cluster) are returned.
+    """
+    by_sig: dict[str, list[str]] = defaultdict(list)
+    for p in _py_files(root):
+        try:
+            tree = ast.parse(p.read_text())
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        rel = p.relative_to(root.parent)
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and _stmt_count(node) >= min_stmts
+            ):
+                by_sig[_signature(node)].append(f"{rel}::{node.name}")
+    return {sig: sorted(set(m)) for sig, m in by_sig.items() if len(set(m)) >= 2}
+
+
+def build_clone_baseline(root: Path) -> list[dict[str, Any]]:
+    """The committed baseline: one entry per accepted clone cluster.
+
+    A list (sorted by first member name for readable diffs) of
+    ``{"signature", "count", "names"}``. ``signature`` is the ratchet key
+    (rename/move-invariant); ``count`` is what may not grow; ``names`` are for
+    human review only.
+    """
+    idx = compute_clone_index(root)
+    entries = [
+        {"signature": sig, "count": len(members), "names": members} for sig, members in idx.items()
+    ]
+    return sorted(entries, key=lambda e: e["names"][0])
+
+
+def compare_clones(baseline: list[dict[str, Any]], current: dict[str, list[str]]) -> list[str]:
+    """Return violations: signatures that are new, or whose cluster grew.
+
+    Keyed on signature, so renames/moves (same structure) never trip it; only a
+    new structural duplicate, or a new member joining a known family, does.
+    """
+    base_count = {e["signature"]: e["count"] for e in baseline}
+    violations: list[str] = []
+    for sig, members in sorted(current.items(), key=lambda kv: kv[1][0]):
+        prior = base_count.get(sig)
+        if prior is None:
+            violations.append("new clone cluster: " + ", ".join(members))
+        elif len(members) > prior:
+            violations.append(f"clone cluster grew {prior}→{len(members)}: " + ", ".join(members))
+    return violations
+
+
+def stale_baseline_clusters(
+    baseline: list[dict[str, Any]], current: dict[str, list[str]]
+) -> list[str]:
+    """Return baseline clusters that shrank or were deduped away (wins to lock in)."""
+    stale: list[str] = []
+    for e in baseline:
+        now = len(current.get(e["signature"], []))
+        if now < e["count"]:
+            stale.append(f"{', '.join(e['names'])} (baseline {e['count']}, now {now})")
+    return stale

--- a/src/dazzle/mcp/knowledge_graph/seed.py
+++ b/src/dazzle/mcp/knowledge_graph/seed.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Bump this when the mapping logic changes to trigger a re-seed
-SEED_SCHEMA_VERSION = 28  # v28: first-party corroboration added to agent-era counter-priors
+SEED_SCHEMA_VERSION = 29  # v29: reinvented-capability filter layer (clone ratchet)
 
 
 def compute_seed_version() -> str:

--- a/src/dazzle/mcp/semantics_kb/core.toml
+++ b/src/dazzle/mcp/semantics_kb/core.toml
@@ -3,7 +3,7 @@
 
 [meta]
 category = "Core Constructs"
-version = "0.87.3"
+version = "0.87.4"
 
 [concepts.entity]
 category = "Core Construct"

--- a/tests/unit/fixtures/clone_baseline.json
+++ b/tests/unit/fixtures/clone_baseline.json
@@ -1,0 +1,816 @@
+[
+  {
+    "signature": "e2431e05ff701b4b6a7331d412a4acd4",
+    "count": 2,
+    "names": [
+      "dazzle/agent/missions/_shared.py::is_step_kind",
+      "dazzle/agent/missions/_shared.py::is_trigger_kind"
+    ]
+  },
+  {
+    "signature": "b9310085bf3332156b1dbc7644b8d9a8",
+    "count": 2,
+    "names": [
+      "dazzle/agent/observer.py::_get_clickable_elements",
+      "dazzle/agent/observer.py::_get_input_fields"
+    ]
+  },
+  {
+    "signature": "ab6c4f241cab113a6ffced188774f346",
+    "count": 5,
+    "names": [
+      "dazzle/api_surface/dsl_constructs.py::diff_against_baseline",
+      "dazzle/api_surface/ir_types.py::diff_against_baseline",
+      "dazzle/api_surface/mcp_tools.py::diff_against_baseline",
+      "dazzle/api_surface/public_helpers.py::diff_against_baseline",
+      "dazzle/api_surface/runtime_urls.py::diff_against_baseline"
+    ]
+  },
+  {
+    "signature": "da19e2332a35f4408d54b55ce21ad3d5",
+    "count": 2,
+    "names": [
+      "dazzle/cli/auth.py::_user_to_dict",
+      "dazzle/mcp/server/handlers/user_management.py::_user_to_dict"
+    ]
+  },
+  {
+    "signature": "889e21d25dedd6c293bcea785dd69890",
+    "count": 3,
+    "names": [
+      "dazzle/cli/discovery.py::discovery_status",
+      "dazzle/cli/e2e/__init__.py::e2e_coverage",
+      "dazzle/cli/e2e/__init__.py::e2e_list_viewport_specs"
+    ]
+  },
+  {
+    "signature": "d51eaf2f6b30eea1e52a13a38d31b098",
+    "count": 3,
+    "names": [
+      "dazzle/cli/pitch.py::pitch_enrich",
+      "dazzle/cli/pitch.py::pitch_init_assets",
+      "dazzle/cli/pitch.py::pitch_review"
+    ]
+  },
+  {
+    "signature": "0d2c953a2239483219d342a64ed16132",
+    "count": 2,
+    "names": [
+      "dazzle/cli/project.py::_is_directory_empty",
+      "dazzle/cli/utils.py::is_directory_empty"
+    ]
+  },
+  {
+    "signature": "f5e64b16260179c3d1bf94b85645bb1f",
+    "count": 2,
+    "names": [
+      "dazzle/cli/project.py::_print_vscode_diagnostics",
+      "dazzle/cli/utils.py::print_vscode_diagnostics"
+    ]
+  },
+  {
+    "signature": "8970021d269b4644eb074a17265d94a2",
+    "count": 2,
+    "names": [
+      "dazzle/cli/project.py::_print_vscode_parse_error",
+      "dazzle/cli/utils.py::print_vscode_parse_error"
+    ]
+  },
+  {
+    "signature": "c17177babd761b1708355c78a36ac086",
+    "count": 4,
+    "names": [
+      "dazzle/cli/pulse.py::pulse_decisions",
+      "dazzle/cli/pulse.py::pulse_radar",
+      "dazzle/cli/pulse.py::pulse_run",
+      "dazzle/cli/pulse.py::pulse_timeline"
+    ]
+  },
+  {
+    "signature": "c110390b0e47acf8a942164d3be42943",
+    "count": 2,
+    "names": [
+      "dazzle/cli/rhythm.py::rhythm_gaps",
+      "dazzle/cli/rhythm.py::rhythm_lifecycle"
+    ]
+  },
+  {
+    "signature": "295385a4ae508e7f34e16d596b9f45d8",
+    "count": 2,
+    "names": [
+      "dazzle/cli/runtime_impl/build.py::_generate_asyncapi_target",
+      "dazzle/cli/runtime_impl/build.py::_generate_openapi_target"
+    ]
+  },
+  {
+    "signature": "c479bdfe2549b6a057ecb62a266392e2",
+    "count": 2,
+    "names": [
+      "dazzle/cli/tenant.py::activate_command",
+      "dazzle/cli/tenant.py::suspend_command"
+    ]
+  },
+  {
+    "signature": "b4e0ffd38e50b64d31a50eea22d325ac",
+    "count": 2,
+    "names": [
+      "dazzle/cli/testing.py::_assert_redirects_to",
+      "dazzle/cli/testing.py::_assert_validation_error"
+    ]
+  },
+  {
+    "signature": "94fb0f17d6c0d78b94e4d49f48a00c32",
+    "count": 2,
+    "names": [
+      "dazzle/cli/testing.py::_assert_state_transition_allowed",
+      "dazzle/cli/testing.py::_assert_state_transition_blocked"
+    ]
+  },
+  {
+    "signature": "a1d18f44636c36c73962208e67055b60",
+    "count": 2,
+    "names": [
+      "dazzle/core/archetype_expander.py::_expand_settings_archetype",
+      "dazzle/core/archetype_expander.py::_expand_tenant_settings_archetype"
+    ]
+  },
+  {
+    "signature": "1848999c67de289544fcc7b18f7f82ca",
+    "count": 2,
+    "names": [
+      "dazzle/core/composition_references_bootstrap.py::_gen_good_cta_alt",
+      "dazzle/core/composition_references_bootstrap.py::_gen_good_hero_alt"
+    ]
+  },
+  {
+    "signature": "bb76ace927d99018af879f998531965d",
+    "count": 2,
+    "names": [
+      "dazzle/core/dsl_parser_impl/audit.py::_parse_audit_retention_days",
+      "dazzle/core/dsl_parser_impl/job.py::_parse_job_timeout"
+    ]
+  },
+  {
+    "signature": "4a2d23dfa463e85718744a66aec00d41",
+    "count": 2,
+    "names": [
+      "dazzle/core/dsl_parser_impl/base.py::parse_module_name",
+      "dazzle/core/dsl_parser_impl/integration.py::_parse_dotted_name"
+    ]
+  },
+  {
+    "signature": "e5cd28cca9c439803b54126e5def01e7",
+    "count": 2,
+    "names": [
+      "dazzle/core/dsl_parser_impl/entity.py::_parse_entity_display_field",
+      "dazzle/core/dsl_parser_impl/entity.py::_parse_entity_domain"
+    ]
+  },
+  {
+    "signature": "d686cdbbc5a61747251cc8c39266e6ea",
+    "count": 2,
+    "names": [
+      "dazzle/core/dsl_parser_impl/entity.py::_parse_entity_signing_template",
+      "dazzle/core/dsl_parser_impl/entity.py::_parse_entity_signing_validator"
+    ]
+  },
+  {
+    "signature": "308267729f9f17ae2da3a12289a30ecc",
+    "count": 2,
+    "names": [
+      "dazzle/core/dsl_parser_impl/grant.py::_grant_skip_to_next_field",
+      "dazzle/core/dsl_parser_impl/question.py::_skip_question_field"
+    ]
+  },
+  {
+    "signature": "c2ae85bfcd14e30bf1227ffc4857445a",
+    "count": 2,
+    "names": [
+      "dazzle/core/dsl_parser_impl/job.py::_on_unknown_job",
+      "dazzle/core/dsl_parser_impl/surface.py::_on_unknown_companion"
+    ]
+  },
+  {
+    "signature": "b9ef809ac48ac257ad8b944c55f0feec",
+    "count": 2,
+    "names": [
+      "dazzle/core/dsl_parser_impl/ledger.py::_parse_dotted_path_ledger",
+      "dazzle/core/dsl_parser_impl/process.py::_parse_dotted_path"
+    ]
+  },
+  {
+    "signature": "56944ea2cf26a17cce65b3d463fe3630",
+    "count": 2,
+    "names": [
+      "dazzle/core/dsl_parser_impl/ledger.py::_parse_expression_string",
+      "dazzle/core/dsl_parser_impl/process.py::_parse_condition_string"
+    ]
+  },
+  {
+    "signature": "f4a23354446ebfcf45ddf3e150d9c3bc",
+    "count": 2,
+    "names": [
+      "dazzle/core/dsl_parser_impl/llm.py::_parse_concurrency_limits",
+      "dazzle/core/dsl_parser_impl/llm.py::_parse_rate_limits"
+    ]
+  },
+  {
+    "signature": "79d43a51065fdbfd37c31d6c33815822",
+    "count": 3,
+    "names": [
+      "dazzle/core/dsl_parser_impl/question.py::_parse_question_text",
+      "dazzle/core/dsl_parser_impl/rule.py::_parse_rule_text",
+      "dazzle/core/dsl_parser_impl/story.py::_parse_condition_expression"
+    ]
+  },
+  {
+    "signature": "8a2126ebd629a0c51d92219f9f7aadd7",
+    "count": 2,
+    "names": [
+      "dazzle/core/dsl_parser_impl/surface.py::_kw_refresh",
+      "dazzle/core/dsl_parser_impl/workspace.py::_kw_refresh"
+    ]
+  },
+  {
+    "signature": "f57c9676cfd4183dae363337aa2cfaf2",
+    "count": 2,
+    "names": [
+      "dazzle/core/dsl_parser_impl/test.py::_assertion_first",
+      "dazzle/core/dsl_parser_impl/test.py::_assertion_last"
+    ]
+  },
+  {
+    "signature": "2a8dc028209dcfb9e312e00ca015ec71",
+    "count": 2,
+    "names": [
+      "dazzle/core/dsl_parser_impl/workspace.py::_parse_entity_card_section_head",
+      "dazzle/core/dsl_parser_impl/workspace.py::_parse_task_inbox_source_head"
+    ]
+  },
+  {
+    "signature": "b2e6c6c5b5f320e5749a53480a03c616",
+    "count": 2,
+    "names": [
+      "dazzle/core/dsl_parser_impl/workspace.py::_parse_pipeline_stage_label",
+      "dazzle/core/dsl_parser_impl/workspace.py::_parse_status_entry_title"
+    ]
+  },
+  {
+    "signature": "db93314a82de6be7d588e6d14b39676e",
+    "count": 2,
+    "names": [
+      "dazzle/core/errors.py::make_link_error",
+      "dazzle/core/errors.py::make_validation_error"
+    ]
+  },
+  {
+    "signature": "68cb3258c82204aaf8dfeda9c99523e4",
+    "count": 2,
+    "names": [
+      "dazzle/core/ir/appspec_queries.py::get_channel",
+      "dazzle/http/specs/backend_spec.py::get_channel"
+    ]
+  },
+  {
+    "signature": "011ace75955a39c6eac5d5432fd04987",
+    "count": 2,
+    "names": [
+      "dazzle/core/ir/appspec_queries.py::get_fixture",
+      "dazzle/core/ir/e2e.py::get_fixture"
+    ]
+  },
+  {
+    "signature": "ad717c950b00bac8e3b63df0fe56c606",
+    "count": 2,
+    "names": [
+      "dazzle/core/ir/appspec_queries.py::get_message",
+      "dazzle/http/specs/backend_spec.py::get_message"
+    ]
+  },
+  {
+    "signature": "f351704bf133cef8429ff5b97fd2ceda",
+    "count": 2,
+    "names": [
+      "dazzle/core/ir/appspec_queries.py::get_surface",
+      "dazzle/page/converters/experience_compiler.py::_find_surface"
+    ]
+  },
+  {
+    "signature": "e71378953b987405ddf1e1c23b5de6f0",
+    "count": 2,
+    "names": [
+      "dazzle/core/ir/appspec_queries.py::get_workspace",
+      "dazzle/page/specs/ui_spec.py::get_workspace"
+    ]
+  },
+  {
+    "signature": "890d5615e4877a13b7db47dedf846bac",
+    "count": 2,
+    "names": [
+      "dazzle/core/ir/computed.py::_collect_expr_dependencies",
+      "dazzle/core/ir/invariant.py::_collect_expr_dependencies"
+    ]
+  },
+  {
+    "signature": "927a39e6dabc4083a7f067fe2d782344",
+    "count": 2,
+    "names": [
+      "dazzle/core/ir/domain.py::get_entity",
+      "dazzle/http/specs/backend_spec.py::get_entity"
+    ]
+  },
+  {
+    "signature": "107410bdd5caae94124c580f5507398e",
+    "count": 5,
+    "names": [
+      "dazzle/core/ir/domain.py::get_field",
+      "dazzle/core/ir/foreign_models.py::get_field",
+      "dazzle/http/specs/entity.py::get_field",
+      "dazzle/http/specs/service.py::get_field",
+      "dazzle/page/specs/component.py::get_field"
+    ]
+  },
+  {
+    "signature": "7348dcc1ca0b0837ea472dada6ef02a3",
+    "count": 2,
+    "names": [
+      "dazzle/core/ir/experiences.py::get_step",
+      "dazzle/core/ir/process.py::get_step"
+    ]
+  },
+  {
+    "signature": "47deb6d67029bde72de741bdda9de94b",
+    "count": 2,
+    "names": [
+      "dazzle/core/ir/state_machine.py::get_allowed_targets",
+      "dazzle/http/specs/entity.py::get_allowed_targets"
+    ]
+  },
+  {
+    "signature": "41dbd70fc8f19db79dab28f93b884cdb",
+    "count": 2,
+    "names": [
+      "dazzle/core/ir/state_machine.py::get_transition",
+      "dazzle/http/specs/entity.py::get_transition"
+    ]
+  },
+  {
+    "signature": "165de02ac571694208ce623dd635ccd9",
+    "count": 2,
+    "names": [
+      "dazzle/core/ir/state_machine.py::get_transitions_from",
+      "dazzle/http/specs/entity.py::get_transitions_from"
+    ]
+  },
+  {
+    "signature": "a863d356cb5196d7158b806cf0e8ce22",
+    "count": 2,
+    "names": [
+      "dazzle/core/process/eventbus_adapter.py::_cron_matches",
+      "dazzle/core/process/postgres_adapter.py::_cron_matches"
+    ]
+  },
+  {
+    "signature": "7bdeac76597d30aa6295077da9177b62",
+    "count": 2,
+    "names": [
+      "dazzle/core/process/eventbus_adapter.py::_match",
+      "dazzle/core/process/postgres_adapter.py::_match"
+    ]
+  },
+  {
+    "signature": "8f107edd2d3e6b166e09d018311bfa98",
+    "count": 2,
+    "names": [
+      "dazzle/core/process/eventbus_adapter.py::_scheduler_loop",
+      "dazzle/core/process/postgres_adapter.py::_scheduler_loop"
+    ]
+  },
+  {
+    "signature": "26051836146954e2d9e9c4c350c34042",
+    "count": 3,
+    "names": [
+      "dazzle/core/process/pg_state.py::get_run",
+      "dazzle/core/process/pg_state.py::get_run_by_idempotency_key",
+      "dazzle/core/process/pg_state.py::get_task"
+    ]
+  },
+  {
+    "signature": "5840cb5ce3c7e54877b6999da2f5d8bb",
+    "count": 2,
+    "names": [
+      "dazzle/core/process/pg_state.py::re_enqueue_run",
+      "dazzle/core/process/pg_state.py::release_run_lease"
+    ]
+  },
+  {
+    "signature": "1bbef0a61f92792948a8858d0ee30a67",
+    "count": 3,
+    "names": [
+      "dazzle/core/process/process_state.py::get_entity_meta",
+      "dazzle/core/process/process_state.py::get_process_spec",
+      "dazzle/core/process/process_state.py::get_schedule_spec"
+    ]
+  },
+  {
+    "signature": "ccc56c305e3e7416af49999c15cad532",
+    "count": 3,
+    "names": [
+      "dazzle/core/question_emitter.py::append_questions_to_dsl",
+      "dazzle/core/rule_emitter.py::append_rules_to_dsl",
+      "dazzle/core/story_emitter.py::append_stories_to_dsl"
+    ]
+  },
+  {
+    "signature": "ccbb86b1c36a4e3783cb370b1236764f",
+    "count": 2,
+    "names": [
+      "dazzle/core/sitespec_loader.py::load_sitespec",
+      "dazzle/core/themespec_loader.py::load_themespec"
+    ]
+  },
+  {
+    "signature": "aed98976a9463f70331873a65a1118c8",
+    "count": 2,
+    "names": [
+      "dazzle/core/sitespec_loader.py::save_sitespec",
+      "dazzle/core/themespec_loader.py::save_themespec"
+    ]
+  },
+  {
+    "signature": "f90d844700ca45fe3c03f0a23fa43dd7",
+    "count": 2,
+    "names": [
+      "dazzle/deploy/generator.py::_get_app_name",
+      "dazzle/deploy/runner.py::_get_app_name"
+    ]
+  },
+  {
+    "signature": "4718c1a8f247dbbbf9f6dc37305509b3",
+    "count": 2,
+    "names": [
+      "dazzle/deploy/stacks/compute.py::generate",
+      "dazzle/deploy/stacks/network.py::generate"
+    ]
+  },
+  {
+    "signature": "690b3090fc2628ca3db75340fa94653b",
+    "count": 2,
+    "names": [
+      "dazzle/http/channels/outbox.py::get_dead_letters",
+      "dazzle/http/channels/outbox.py::get_recent"
+    ]
+  },
+  {
+    "signature": "3d12e6fa6c29b415ca16955a99f5fd8d",
+    "count": 2,
+    "names": [
+      "dazzle/http/channels/outbox.py::mark_processing",
+      "dazzle/http/channels/outbox.py::retry_dead_letter"
+    ]
+  },
+  {
+    "signature": "e3f6a2a903759e1974f47c62335c37f9",
+    "count": 3,
+    "names": [
+      "dazzle/http/data_products/transformer.py::_mask_card",
+      "dazzle/http/data_products/transformer.py::_mask_phone",
+      "dazzle/http/data_products/transformer.py::_mask_ssn"
+    ]
+  },
+  {
+    "signature": "fe04858999e64930b9ea9e531acbeebb",
+    "count": 2,
+    "names": [
+      "dazzle/http/events/base_event_bus.py::_cancel_consumer_tasks",
+      "dazzle/http/events/base_event_bus.py::stop_consumer_loop"
+    ]
+  },
+  {
+    "signature": "c6a4a3cdf7a55e706a282b6ac0759750",
+    "count": 2,
+    "names": [
+      "dazzle/http/pra/harness.py::generate_report",
+      "dazzle/http/pra/tigerbeetle_harness.py::generate_report"
+    ]
+  },
+  {
+    "signature": "afc06a788667c0905d5923336329cbd2",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/access_control.py::create_authenticated",
+      "dazzle/http/runtime/access_control.py::create_public"
+    ]
+  },
+  {
+    "signature": "38b80ab1aec659f00f913657ad66e678",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/app_factory.py::_fetch_by_id",
+      "dazzle/http/runtime/app_factory.py::_history_lookup"
+    ]
+  },
+  {
+    "signature": "caa0527e353ca0f13b285a780f5eb8c9",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/auth/connection_admin_routes.py::_gate",
+      "dazzle/http/runtime/auth/member_admin_routes.py::_gate"
+    ]
+  },
+  {
+    "signature": "6ca9e766589731c5378a623a05b65063",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/auth/enterprise_routes.py::_resolve_connection",
+      "dazzle/http/runtime/auth/saml_routes.py::_resolve_saml_connection"
+    ]
+  },
+  {
+    "signature": "913e7986391b90a8590135eac7a345b9",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/auth/enterprise_routes.py::enterprise_login",
+      "dazzle/http/runtime/auth/saml_routes.py::saml_login"
+    ]
+  },
+  {
+    "signature": "fa16e8a6dea19aed1145becdb27c7221",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/auth/mailer.py::get_invitation_mailer",
+      "dazzle/http/runtime/auth/mailer.py::get_verification_mailer"
+    ]
+  },
+  {
+    "signature": "b98a69b274b9538fbf65f595a0606ca6",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/auth/member_admin_routes.py::_resolve_target",
+      "dazzle/http/runtime/auth/scim_routes.py::_membership_in_org"
+    ]
+  },
+  {
+    "signature": "122f3d2904aaf65dbe993f95f65a4900",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/auth/middleware.py::is_excluded_path",
+      "dazzle/http/runtime/jwt_middleware.py::_is_excluded_path"
+    ]
+  },
+  {
+    "signature": "09cdac775e2da6f35af97f467eee48d1",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/auth/routes_2fa.py::_get_otp_store",
+      "dazzle/http/runtime/auth/routes_2fa.py::_get_recovery_store"
+    ]
+  },
+  {
+    "signature": "51f3067e4b3fbaf2037d289491c3e7c7",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/auth/store.py::disable_connection_assertion_encryption",
+      "dazzle/http/runtime/auth/store.py::disable_connection_request_signing"
+    ]
+  },
+  {
+    "signature": "526ad8a6acf09cc2713fbbc3d8887575",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/auth/store.py::enable_connection_assertion_encryption",
+      "dazzle/http/runtime/auth/store.py::enable_connection_request_signing"
+    ]
+  },
+  {
+    "signature": "8b9d53209fa1fc837f46c55af6fbea15",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/aws_config.py::get_aioboto3_session",
+      "dazzle/http/runtime/aws_config.py::get_boto3_session"
+    ]
+  },
+  {
+    "signature": "d100312e7baa6130f0f2d2331127a925",
+    "count": 4,
+    "names": [
+      "dazzle/http/runtime/device_registry.py::_init_db",
+      "dazzle/http/runtime/otp_store.py::init_db",
+      "dazzle/http/runtime/recovery_codes.py::init_db",
+      "dazzle/http/runtime/token_store.py::_init_db"
+    ]
+  },
+  {
+    "signature": "5d4130261ee3008b68e9fddfe088586a",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/device_registry.py::ensure_device_tables",
+      "dazzle/http/runtime/token_store.py::ensure_refresh_token_tables"
+    ]
+  },
+  {
+    "signature": "1ab2b34f8eb73ec30edb98ae4b18b286",
+    "count": 4,
+    "names": [
+      "dazzle/http/runtime/handlers/graph_handlers.py::_check_networkx",
+      "dazzle/http/runtime/richtext_processor.py::is_available",
+      "dazzle/pitch/generators/charts.py::_check_matplotlib_available",
+      "dazzle/pitch/generators/pptx_gen.py::_check_pptx_available"
+    ]
+  },
+  {
+    "signature": "9b4e98cc859e95ebf905605730cbd0ec",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/integration_executor.py::evaluate_expression",
+      "dazzle/http/runtime/mapping_executor.py::_evaluate_expression"
+    ]
+  },
+  {
+    "signature": "5d204fe534f6b14d4e9a0f82db33c10b",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/integration_manager.py::get_channel_status",
+      "dazzle/http/runtime/subsystems/channels.py::get_channel_status"
+    ]
+  },
+  {
+    "signature": "f5206c1d26725eb30c9c7dcd4d45674c",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/integration_manager.py::send_message",
+      "dazzle/http/runtime/subsystems/channels.py::send_message"
+    ]
+  },
+  {
+    "signature": "7eb9fd2b59a9431eff3510576154c410",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/pg_backend.py::get_table_columns",
+      "dazzle/http/runtime/pg_backend.py::get_table_indexes"
+    ]
+  },
+  {
+    "signature": "60896f717758631dbb8e2889a8088cdb",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/renderers/site_section_builder.py::_build_faq_section",
+      "dazzle/http/runtime/renderers/site_section_builder.py::_build_stats_section"
+    ]
+  },
+  {
+    "signature": "d06a88ad268a7d404c196a0285827310",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/site_routes.py::forgot_password_sent_page",
+      "dazzle/http/runtime/site_routes.py::reset_password_done_page"
+    ]
+  },
+  {
+    "signature": "c2ee9525590f366f9ee37ffab5f34f88",
+    "count": 3,
+    "names": [
+      "dazzle/http/runtime/site_routes.py::serve_page",
+      "dazzle/http/runtime/site_routes.py::serve_privacy_page",
+      "dazzle/http/runtime/site_routes.py::serve_terms_page"
+    ]
+  },
+  {
+    "signature": "b8b3c52354b218d9c282abfeb3e245ed",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/site_routes.py::two_factor_settings_page",
+      "dazzle/http/runtime/site_routes.py::two_factor_setup_page"
+    ]
+  },
+  {
+    "signature": "5e258a1595765461974078484ff581d1",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/storage/proxy_routes.py::_expected_prefix_pattern",
+      "dazzle/http/runtime/storage/verify.py::_expected_prefix_pattern"
+    ]
+  },
+  {
+    "signature": "7d6d80c67f51b24ab89b4ec14a6644e3",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/subsystems/auth.py::_mount_enterprise_sso",
+      "dazzle/http/runtime/subsystems/auth.py::_mount_saml"
+    ]
+  },
+  {
+    "signature": "33ff9c1dbab909bd48fb7733b64a76d4",
+    "count": 2,
+    "names": [
+      "dazzle/http/runtime/token_store.py::revoke_token",
+      "dazzle/http/runtime/token_store.py::use_token"
+    ]
+  },
+  {
+    "signature": "3b9cb5a8832f05aaff03279d9d3b4913",
+    "count": 4,
+    "names": [
+      "dazzle/mcp/event_first_tools.py::handle_infer_analytics",
+      "dazzle/mcp/event_first_tools.py::handle_infer_compliance",
+      "dazzle/mcp/event_first_tools.py::handle_infer_tenancy",
+      "dazzle/mcp/event_first_tools.py::handle_validate_events"
+    ]
+  },
+  {
+    "signature": "405f7fb0f67f8c9f6efeb3858653e356",
+    "count": 2,
+    "names": [
+      "dazzle/mcp/knowledge_graph/metadata.py::get_seed_meta",
+      "dazzle/mcp/knowledge_graph/metadata.py::resolve_alias"
+    ]
+  },
+  {
+    "signature": "ebb56b50b43ee3955fb78139278c765a",
+    "count": 2,
+    "names": [
+      "dazzle/mcp/server/handlers/db.py::db_status_handler",
+      "dazzle/mcp/server/handlers/db.py::db_verify_handler"
+    ]
+  },
+  {
+    "signature": "86e2c0b93bf724702508f420253faf6f",
+    "count": 2,
+    "names": [
+      "dazzle/mcp/server/handlers/project.py::load_appspec_for_project",
+      "dazzle/mcp/server/tool_handlers.py::load_appspec_for_project"
+    ]
+  },
+  {
+    "signature": "d4492c3056181776338c106a04a47708",
+    "count": 2,
+    "names": [
+      "dazzle/mcp/server/handlers/project.py::validate_all_projects",
+      "dazzle/mcp/server/tool_handlers.py::validate_all_projects"
+    ]
+  },
+  {
+    "signature": "de23ddc05e3966ca0867b98060de6d41",
+    "count": 2,
+    "names": [
+      "dazzle/mcp/server/handlers/test_design/proposals.py::_parse_test_design_action",
+      "dazzle/mcp/server/handlers/test_design/proposals.py::_parse_test_design_trigger"
+    ]
+  },
+  {
+    "signature": "c670fb65f17edfc12d8ddb1a306f3696",
+    "count": 2,
+    "names": [
+      "dazzle/mcp/server/handlers_consolidated.py::_make_project_handler",
+      "dazzle/mcp/server/handlers_consolidated.py::_make_standalone_handler"
+    ]
+  },
+  {
+    "signature": "3ecedf5cf116cd7b87fc2df645389613",
+    "count": 2,
+    "names": [
+      "dazzle/mcp/server/tool_handlers.py::get_workflow_guide_handler",
+      "dazzle/mcp/server/tool_handlers.py::lookup_concept_handler"
+    ]
+  },
+  {
+    "signature": "d1fd251097bc48e047126f66466f5278",
+    "count": 2,
+    "names": [
+      "dazzle/perf/storage.py::iter_events",
+      "dazzle/perf/storage.py::iter_spans"
+    ]
+  },
+  {
+    "signature": "c226f1e4225b046145b681dee207d8d5",
+    "count": 2,
+    "names": [
+      "dazzle/pitch/generators/pptx_primitives.py::_create_dark_slide",
+      "dazzle/pitch/generators/pptx_primitives.py::_create_light_slide"
+    ]
+  },
+  {
+    "signature": "acea8d62df86d72b07a763c22162a83e",
+    "count": 2,
+    "names": [
+      "dazzle/render/filters.py::_pagination_pages",
+      "dazzle/render/fragment/renderer/_helpers.py::_pagination_pages"
+    ]
+  },
+  {
+    "signature": "ed41f50ad12ca02034323484685c5eb5",
+    "count": 2,
+    "names": [
+      "dazzle/render/onboarding/renderer.py::_build_inline_card_step",
+      "dazzle/render/onboarding/renderer.py::_build_popover_step"
+    ]
+  },
+  {
+    "signature": "0058b302f5983b814bd6fa1fa5c171b7",
+    "count": 2,
+    "names": [
+      "dazzle/specs/asyncapi.py::asyncapi_to_yaml",
+      "dazzle/specs/openapi.py::openapi_to_yaml"
+    ]
+  }
+]

--- a/tests/unit/test_clone_ratchet.py
+++ b/tests/unit/test_clone_ratchet.py
@@ -1,0 +1,155 @@
+"""Framework structural-fitness — the clone (reuse) ratchet.
+
+Layer-3 filter for the ``reinvented-capability`` counter-prior. A duplication
+creep gate, same posture as the complexity ratchet: a *new* or *grown* clone
+cluster (a function re-implementing a structure that already exists) is a
+regression. Dedup, or — if a cluster is parallel-by-design accepted residue —
+regenerate with ``dazzle fitness clones --write-baseline``.
+
+NEVER run ``ruff format`` over the .json baseline (the v0.83.16 lesson — it
+injects a trailing comma and breaks JSON parsing).
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from dazzle.fitness.clones import (
+    _signature,
+    build_clone_baseline,
+    compare_clones,
+    compute_clone_index,
+    stale_baseline_clusters,
+)
+
+pytestmark = pytest.mark.gate
+
+_BASELINE = Path("tests/unit/fixtures/clone_baseline.json")
+_SRC = Path("src/dazzle")
+
+
+def test_baseline_is_valid_json() -> None:
+    data = json.loads(_BASELINE.read_text())
+    assert isinstance(data, list) and data
+    assert all(
+        {"signature", "count", "names"} <= e.keys() and e["count"] == len(e["names"]) >= 2
+        for e in data
+    )
+
+
+def test_current_tree_does_not_regress_against_baseline() -> None:
+    baseline = json.loads(_BASELINE.read_text())
+    current = compute_clone_index(_SRC)
+    violations = compare_clones(baseline, current)
+    assert violations == [], (
+        f"{len(violations)} duplication regression(s) — reuse the existing function "
+        f"instead of re-implementing it, or `dazzle fitness clones --write-baseline` "
+        f"if the cluster is parallel-by-design accepted residue:\n  " + "\n  ".join(violations[:20])
+    )
+
+
+def test_baseline_has_no_stale_clusters() -> None:
+    """A cluster that shrank or was deduped must be re-baselined (lock the win)."""
+    baseline = json.loads(_BASELINE.read_text())
+    current = compute_clone_index(_SRC)
+    stale = stale_baseline_clusters(baseline, current)
+    assert stale == [], (
+        f"{len(stale)} baseline cluster(s) shrank or were deduped — "
+        f"regenerate with `dazzle fitness clones --write-baseline` to lock the win:\n  "
+        + "\n  ".join(stale[:20])
+    )
+
+
+# --- detector unit tests (synthetic) ---
+
+
+def _write(tmp_path: Path, name: str, body: str) -> None:
+    (tmp_path / name).write_text(body)
+
+
+def test_detects_type2_clone(tmp_path: Path) -> None:
+    """Two functions with identical structure (different names + literals) cluster."""
+    _write(
+        tmp_path,
+        "a.py",
+        "def alpha(items):\n"
+        "    out = []\n"
+        "    for it in items:\n"
+        "        if it > 1:\n"
+        "            out.append(it)\n"
+        "    return out\n",
+    )
+    _write(
+        tmp_path,
+        "b.py",
+        "def bravo(rows):\n"
+        "    acc = []\n"
+        "    for r in rows:\n"
+        "        if r > 9:\n"
+        "            acc.append(r)\n"
+        "    return acc\n",
+    )
+    index = compute_clone_index(tmp_path)
+    assert len(index) == 1
+    members = next(iter(index.values()))
+    names = {m.split("::")[1] for m in members}
+    assert names == {"alpha", "bravo"}
+
+
+def test_rename_and_move_do_not_trip_the_gate(tmp_path: Path) -> None:
+    """The ratchet is signature-keyed, so renaming/moving a clustered function
+    is NOT a violation (no new duplication) — the key fix vs name-keying."""
+    body = (
+        "def {name}({arg}):\n"
+        "    out = []\n"
+        "    for it in {arg}:\n"
+        "        if it > 1:\n"
+        "            out.append(it)\n"
+        "    return out\n"
+    )
+    _write(tmp_path, "a.py", body.format(name="alpha", arg="items"))
+    _write(tmp_path, "b.py", body.format(name="bravo", arg="rows"))
+    baseline = build_clone_baseline(tmp_path)
+    # rename both functions (and the move case is identical — the signature is
+    # body-only, so relpath::name changing for both reasons leaves it unchanged)
+    _write(tmp_path, "a.py", body.format(name="renamed_alpha", arg="xs"))
+    _write(tmp_path, "b.py", body.format(name="renamed_bravo", arg="ys"))
+    current = compute_clone_index(tmp_path)
+    assert compare_clones(baseline, current) == []  # no spurious "duplication" violation
+    assert stale_baseline_clusters(baseline, current) == []  # not flagged stale either
+
+
+def test_distinct_structure_not_clustered(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "a.py",
+        "def alpha(items):\n"
+        "    out = []\n"
+        "    for it in items:\n"
+        "        out.append(it)\n"
+        "    return out\n",
+    )
+    _write(
+        tmp_path,
+        "b.py",
+        "def bravo(x):\n"
+        "    if x:\n"
+        "        return x * 2\n"
+        "    while x:\n"
+        "        x -= 1\n"
+        "    return x\n",
+    )
+    assert compute_clone_index(tmp_path) == {}
+
+
+def test_signature_blanks_names_keeps_api() -> None:
+    """Same shape + same method call -> same signature; different method -> different."""
+    f1 = ast.parse("def f(a):\n    return a.encode()\n    x = 1\n    y = 2\n    z = 3").body[0]
+    f2 = ast.parse("def g(b):\n    return b.encode()\n    p = 9\n    q = 8\n    r = 7").body[0]
+    f3 = ast.parse("def h(c):\n    return c.decode()\n    p = 9\n    q = 8\n    r = 7").body[0]
+    assert _signature(f1) == _signature(f2)  # renamed locals/literals -> same
+    assert _signature(f1) != _signature(f3)  # different method (.encode vs .decode)

--- a/uv.lock
+++ b/uv.lock
@@ -912,7 +912,7 @@ wheels = [
 
 [[package]]
 name = "dazzle-dsl"
-version = "0.87.3"
+version = "0.87.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Turns the [reuse-detection research note](https://github.com/manwithacat/dazzle/blob/main/docs/research/reuse-detection.md) into a shipped framework feature: the **layer-3 filter** for the [`reinvented-capability`](https://github.com/manwithacat/dazzle/blob/main/docs/counter-priors/reinvented-capability.md) counter-prior. That prior previously had only an inference-layer reflection prompt; this completes its **grammar / inference / filter** coverage.

- **`dazzle fitness clones`** — detects Type-2 function clones (structural signature: arg arity + control-flow shape + called-method/keyword names, modulo local names and literal values).
- **Clone ratchet** (`tests/unit/test_clone_ratchet.py`, baseline `clone_baseline.json` — 99 clusters / 220 functions) — fails the build on a *new* or *grown* duplicate cluster, mirroring the established complexity-ratchet idiom. Parallel-by-design families are grandfathered as accepted residue; `--write-baseline` is the escape hatch.

## Review-hardened

An adversarial review of the gate caught three issues, all fixed properly:
1. **Rename/move misfire** — the ratchet is now keyed on the **signature** (which is body-only, so rename/move-invariant), not on function names. A pure rename/move never trips it. Regression test added.
2. **Coverage hole** — the test-file exclusion was a substring match (`"test" in name`) that silently skipped ~15 production `testing/` and `*_generator` modules. Anchored to `test_*` / `tests/`.
3. **Precision** — added argument arity to the signature.

Verified: 276 tests pass across fitness/clone/counter-prior suites; `mypy` + `ruff` clean. KG re-seeds (`SEED_SCHEMA_VERSION` 28→29). Released as **v0.87.4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🔖 Claude-lens: dazzle