### PR TITLE
feat(spec-narrative): DSL → stakeholder specification (v0.89.0)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -255,7 +255,7 @@ The table below is drift-gated against the live registry (`tests/unit/test_docs_
 | `db` | status, verify |
 | `demo_data` | get |
 | `discovery` | coherence |
-| `dsl` | validate, list_modules, inspect_entity, inspect_surface, analyze, lint, get_spec, fidelity, list_fragments, export_frontend_spec |
+| `dsl` | validate, list_modules, inspect_entity, inspect_surface, analyze, lint, get_spec, fidelity, list_fragments, export_frontend_spec, brief |
 | `e2e` | list_modes, describe_mode, status, list_baselines |
 | `feedback` | list, get, triage, resolve |
 | `fitness` | queue |
@@ -312,6 +312,30 @@ dazzle api-pack generate-dsl|env-vars|infrastructure|scaffold
 dazzle mock scenarios|fire-webhook|inject-error|scaffold-scenario
 dazzle contribution templates|create|validate|examples
 ```
+
+## Specification Narrative (DSL → stakeholder prose)
+
+Reverse the DSL→app flow into a non-technical specification document for
+investors, business leaders, and founders:
+
+- `dazzle spec brief [--project DIR] [--format json|text]` — deterministic Stage 1.
+  Emits a fact-only `SpecBrief`: app facts (entities/personas/surfaces/lifecycles,
+  with framework-`platform` plumbing excluded), security posture, and **framework
+  value-claims** that activate only when a named detector fires against the AppSpec
+  (so the document never asserts a capability the app doesn't exercise).
+- `dsl` MCP tool, `brief` op — stateless read mirror of `dazzle spec brief`
+  (returns the same JSON), for in-session agents that prefer MCP over shelling out.
+- `/spec-narrate` skill — agent-driven Stage 2. Reads the brief as the single
+  source of truth and writes a layered `SPECIFICATION.md` (exec summary → depth);
+  every sentence must trace to the brief.
+
+To add/reword a framework guarantee, edit `src/dazzle/spec_narrative/claims.toml`;
+each claim names a detector in `spec_narrative/detectors.py` and carries an
+`evidence` command a skeptic can run. The claim-integrity test
+(`tests/unit/test_spec_narrative_claims.py`) gates that every claim's detector
+exists; the `simple_task` brief is golden-snapshotted
+(`tests/unit/test_spec_narrative_brief_snapshot.py` — regenerate with
+`dazzle spec brief -p examples/simple_task -f json > tests/unit/baselines/spec_brief_simple_task.json`).
 
 ## PyPI Package
 
@@ -375,4 +399,4 @@ Example: `examples/ops_dashboard` has working `bar_chart` (FK `group_by: system`
 - **KG re-seeding**: `ensure_seeded()` checks a version key; bump it in `seed.py` when TOML data changes.
 
 ---
-**Version**: 0.88.9 | **Python**: 3.12+ | **Status**: Production Ready
+**Version**: 0.89.0 | **Python**: 3.12+ | **Status**: Production Ready

--- a/.claude/skills/spec-narrate/SKILL.md
+++ b/.claude/skills/spec-narrate/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: spec-narrate
+description: Use when the user wants to generate a stakeholder-facing English specification document (SPECIFICATION.md) from a Dazzle DSL project — for investors, business leaders, founders, or non-technical decision-makers. Reverses the usual DSL→app flow into DSL→prose.
+---
+
+# spec-narrate — DSL → stakeholder specification
+
+Turn a Dazzle project's DSL into `SPECIFICATION.md`: a single, layered,
+non-technical document (executive summary → progressive depth) that explains
+what the system does, who uses it, how work flows through it, and the technical
+guarantees that hold *because it is built on Dazzle*.
+
+## The hard rule
+
+The brief is the **single source of truth**. Every sentence you write MUST trace
+to a fact or an activated claim in the brief. **Invent nothing** — no metrics, no
+roadmap, no capabilities, no market claims that aren't in the brief. If a section
+has no supporting facts, omit it. An investor-facing document that overstates is
+worse than one that is terse.
+
+## Steps
+
+1. Run the deterministic extractor:
+   ```bash
+   dazzle spec brief --project <dir> --format json
+   ```
+   (Default `<dir>` is `.`.) Parse the JSON. It contains:
+   - `app_name` / `app_title`
+   - `domain` — the things the system manages (each with `title`, `intent`,
+     `lifecycle_states`). Framework plumbing is already excluded.
+   - `actors` — personas (`id`, `label`, `description`)
+   - `capabilities` — surfaces (`name`, `title`, `entity`, `mode`)
+   - `security` — `has_row_level_security`, `scoped_entities`, `persona_count`
+   - `activated_claims` — framework guarantees that fired, each with `group`,
+     `audience`, `claim` text, and an `evidence` command
+   - `skeleton` — which sections to write (`populated`) and which claim ids
+     belong in each (`claim_ids`)
+
+2. Write `SPECIFICATION.md` at the project root, following the skeleton's section
+   order. Only write sections whose skeleton entry has `populated: true`.
+
+   - **Executive summary** — 2–3 paragraphs: what the system is (from `app_title`
+     + the domain), who it's for (from `actors`), and 1–2 standout guarantees
+     (pick the highest-impact `investor`-audience activated claims).
+   - **What it does** — narrate `domain` items in plain English using each item's
+     `title`/`intent`. Group related entities. No database vocabulary (no
+     "tables", "foreign keys", "columns").
+   - **Who uses it** — narrate `actors` (label + description) and, drawing on
+     `capabilities`, what each can accomplish.
+   - **How work flows through it** — narrate entities that have `lifecycle_states`
+     as journeys ("a Task moves from todo → in progress → review → done"), plus
+     approvals.
+   - **The technical foundation** — for each claim id in the skeleton's
+     `technical_foundation.claim_ids`, write the matching `claim` text in your own
+     flowing prose, grouped by `group` (Security, Data & reliability,
+     Architecture). After each guarantee, note that it can be independently
+     verified (cite the claim's `evidence` command). This verifiability is a
+     selling point — lean into it.
+   - **Compliance posture** — only if populated; narrate the compliance-group
+     claim(s).
+
+3. Self-check before finishing: re-read each paragraph. Does any sentence assert
+   something not present in the brief? Delete it. Does any claim text appear that
+   wasn't in `activated_claims`? Delete it.
+
+4. Tell the user where the document is and which claims activated (so they can
+   see which guarantees their app currently earns).
+
+## Tone
+
+Confident but substantiated. Every architectural assertion is backed by an
+`evidence` command — write like someone who can prove what they say. Avoid hype
+adjectives ("revolutionary", "cutting-edge"); let the guarantees speak.
+
+## Notes
+
+- This is Stage 2 of a two-stage pipeline; Stage 1 (`dazzle spec brief`) is
+  deterministic and tested. You are the language layer.
+- To add or reword a framework guarantee, edit
+  `src/dazzle/spec_narrative/claims.toml` (not this skill).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.89.0] - 2026-06-28
+
+### Added
+- **Specification Narrative (`dazzle spec brief` + `/spec-narrate`)** — generate a
+  stakeholder-facing `SPECIFICATION.md` from the DSL, reversing the usual DSL→app
+  flow into DSL→prose for investors, business leaders, and founders. Stage 1
+  (`dazzle spec brief`) deterministically extracts app facts (entities/personas/
+  surfaces/lifecycles, with framework-`platform` plumbing excluded) plus
+  detector-gated framework value-claims (RLS, provable RBAC, Postgres, SSR, HLESS
+  event semantics, multi-tenancy, compliance evidence); Stage 2 (the `/spec-narrate`
+  skill) renders them to a layered, non-technical document. New package
+  `src/dazzle/spec_narrative/` (claim catalogue in `claims.toml`, gated by
+  `detectors.py`). Claim integrity + a `simple_task` golden brief snapshot are
+  drift-gated. Also exposed as the `dsl` MCP tool's `brief` op (stateless read
+  mirror) for in-session agents that prefer MCP over shelling out to the CLI.
+
+### Agent Guidance
+- **Stakeholder spec generation.** To add or reword a framework guarantee shown to
+  stakeholders, edit `src/dazzle/spec_narrative/claims.toml` — each claim is gated
+  by a detector in `detectors.py` and carries an `evidence` command a skeptic can
+  run. The `/spec-narrate` skill must trace every sentence to the `dazzle spec brief`
+  output; it invents nothing. The brief excludes framework `domain == "platform"`
+  entities (AIJob, FeedbackReport, …) so they never leak into a non-technical doc.
+
 ## [0.88.9] - 2026-06-28
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # DAZZLE Development Roadmap
 
 **Last Updated**: 2026-06-16
-**Current Version**: v0.88.9
+**Current Version**: v0.89.0
 
 For past releases, see [CHANGELOG.md](CHANGELOG.md).
 

--- a/docs/api-surface/mcp-tools.txt
+++ b/docs/api-surface/mcp-tools.txt
@@ -322,8 +322,8 @@ tool: discovery
   }
 
 tool: dsl
-  description_hash: f031b49924ad
-  description_len: 385
+  description_hash: 800dd35f88b8
+  description_len: 543
   {
     "properties": {
       "entities": {
@@ -372,7 +372,8 @@ tool: dsl
           "get_spec",
           "fidelity",
           "list_fragments",
-          "export_frontend_spec"
+          "export_frontend_spec",
+          "brief"
         ],
         "type": "string"
       },

--- a/homebrew/dazzle.rb
+++ b/homebrew/dazzle.rb
@@ -10,10 +10,10 @@ class Dazzle < Formula
 
   desc "DSL-first application framework with LLM-assisted development"
   homepage "https://github.com/manwithacat/dazzle"
-  version "0.88.9"
+  version "0.89.0"
   license "MIT"
 
-  url "https://github.com/manwithacat/dazzle/archive/refs/tags/v0.88.9.tar.gz"
+  url "https://github.com/manwithacat/dazzle/archive/refs/tags/v0.89.0.tar.gz"
   sha256 "PLACEHOLDER_SOURCE_SHA256"
 
   # pydantic-core requires Rust to build from source, so use pre-built wheels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dazzle-dsl"
-version = "0.88.9"
+version = "0.89.0"
 description = "DAZZLE — declarative SaaS framework with built-in compliance (SOC 2, ISO 27001), provable RBAC, and graph features"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/dazzle/cli/spec.py
+++ b/src/dazzle/cli/spec.py
@@ -24,6 +24,7 @@ from dazzle.core import ir
 from dazzle.core.appspec_loader import load_project_appspec
 from dazzle.core.spec_loader import load_spec
 from dazzle.core.strings import to_api_plural
+from dazzle.spec_narrative import SpecBrief, build_brief
 
 logger = logging.getLogger(__name__)
 
@@ -647,3 +648,57 @@ def _manifest_strict_enabled(project_dir: Path) -> bool:
             exc_info=True,
         )
         return False
+
+
+@spec_app.command(name="brief")
+def spec_brief(
+    project_dir: Path = typer.Option(
+        Path("."),
+        "--project",
+        "-p",
+        help="Project directory (default: current directory).",
+    ),
+    output_format: str = typer.Option(
+        "json",
+        "--format",
+        "-f",
+        help="Output format: 'json' (machine, for /spec-narrate) or 'text' (human preview).",
+    ),
+) -> None:
+    """Emit a deterministic spec brief: verified app facts + activated framework claims.
+
+    Stage 1 of DSL → SPECIFICATION.md. The JSON output is the single source of
+    truth for the ``/spec-narrate`` skill, which writes the prose document.
+    """
+    try:
+        appspec = load_project_appspec(project_dir)
+    except Exception as exc:  # noqa: BLE001 — surface any load failure to the user
+        typer.echo(f"Error loading DSL: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    brief = build_brief(appspec)
+    if output_format == "text":
+        typer.echo(_format_brief_text(brief))
+    else:
+        typer.echo(brief.model_dump_json(indent=2))
+
+
+def _format_brief_text(brief: SpecBrief) -> str:
+    """Render a compact human-readable preview of the brief."""
+    lines: list[str] = [f"SPEC BRIEF — {brief.app_title or brief.app_name}", ""]
+    lines.append(f"Domain ({len(brief.domain)} entities):")
+    for d in brief.domain:
+        states = f" [{', '.join(d.lifecycle_states)}]" if d.lifecycle_states else ""
+        lines.append(f"  - {d.title or d.name}{states}")
+    lines.append("")
+    lines.append(f"Actors ({len(brief.actors)}): " + ", ".join(a.label for a in brief.actors))
+    lines.append("")
+    lines.append("Activated framework claims:")
+    for c in brief.activated_claims:
+        lines.append(f"  - [{c.group}] {c.id} (verify: {c.evidence})")
+    lines.append("")
+    lines.append("Document sections:")
+    for s in brief.skeleton:
+        mark = "x" if s.populated else " "
+        lines.append(f"  [{mark}] {s.section}")
+    return "\n".join(lines)

--- a/src/dazzle/mcp/semantics_kb/core.toml
+++ b/src/dazzle/mcp/semantics_kb/core.toml
@@ -3,7 +3,7 @@
 
 [meta]
 category = "Core Constructs"
-version = "0.88.9"
+version = "0.89.0"
 
 [concepts.entity]
 category = "Core Construct"

--- a/src/dazzle/mcp/server/handlers_consolidated.py
+++ b/src/dazzle/mcp/server/handlers_consolidated.py
@@ -216,6 +216,15 @@ def _dsl_list_fragments(project_path: Path, args: dict[str, Any]) -> str:
     return json.dumps({"fragments": get_fragment_registry()}, indent=2)
 
 
+def _dsl_brief(project_path: Path, args: dict[str, Any]) -> str:
+    """Stateless read mirror of `dazzle spec brief` — the spec-narrative brief."""
+    from dazzle.core.appspec_loader import load_project_appspec
+    from dazzle.spec_narrative.brief import build_brief
+
+    appspec = load_project_appspec(project_path)
+    return build_brief(appspec).model_dump_json(indent=2)
+
+
 handle_dsl: Callable[[dict[str, Any]], str] = _make_project_handler(
     "DSL",
     {
@@ -230,6 +239,7 @@ handle_dsl: Callable[[dict[str, Any]], str] = _make_project_handler(
         "fidelity": f"{_MOD_DSL_FIDELITY}:score_fidelity_handler",
         "export_frontend_spec": f"{_MOD_DSL}:export_frontend_spec_handler",
         "list_fragments": _dsl_list_fragments,
+        "brief": _dsl_brief,
     },
 )
 

--- a/src/dazzle/mcp/server/tools_consolidated.py
+++ b/src/dazzle/mcp/server/tools_consolidated.py
@@ -71,7 +71,7 @@ def _tool_dsl() -> Tool:
     """DSL operations (replaces 7 tools)."""
     return Tool(
         name="dsl",
-        description="DSL operations: validate, list_modules, inspect_entity, inspect_surface, analyze, lint, get_spec, fidelity, list_fragments, export_frontend_spec. NOTE: export_frontend_spec produces a LARGE output intended for human developers migrating away from Dazzle — always use 'sections' and/or 'entities' filters to avoid flooding context. Prefer inspect_entity/inspect_surface for LLM queries.",
+        description="DSL operations: validate, list_modules, inspect_entity, inspect_surface, analyze, lint, get_spec, fidelity, list_fragments, export_frontend_spec, brief. 'brief' returns the deterministic stakeholder spec-brief (fact-only app facts + activated framework value-claims) consumed by the /spec-narrate skill. NOTE: export_frontend_spec produces a LARGE output intended for human developers migrating away from Dazzle — always use 'sections' and/or 'entities' filters to avoid flooding context. Prefer inspect_entity/inspect_surface for LLM queries.",
         inputSchema={
             "type": "object",
             "properties": {
@@ -88,6 +88,7 @@ def _tool_dsl() -> Tool:
                         "fidelity",
                         "list_fragments",
                         "export_frontend_spec",
+                        "brief",
                     ],
                     "description": "Operation to perform",
                 },

--- a/src/dazzle/spec_narrative/__init__.py
+++ b/src/dazzle/spec_narrative/__init__.py
@@ -1,0 +1,10 @@
+"""DSL → stakeholder specification narrative.
+
+Stage 1 (deterministic): extract a fact-only ``SpecBrief`` from an AppSpec.
+Stage 2 (agent-driven): the ``/spec-narrate`` skill renders the brief to prose.
+"""
+
+from dazzle.spec_narrative.brief import build_brief
+from dazzle.spec_narrative.models import SpecBrief
+
+__all__ = ["SpecBrief", "build_brief"]

--- a/src/dazzle/spec_narrative/brief.py
+++ b/src/dazzle/spec_narrative/brief.py
@@ -1,0 +1,141 @@
+"""Build a fact-only SpecBrief from an AppSpec: facts + activated claims + skeleton."""
+
+from dazzle.core import ir
+from dazzle.spec_narrative.claims import load_claims
+from dazzle.spec_narrative.detectors import REGISTRY
+from dazzle.spec_narrative.models import (
+    ActivatedClaim,
+    ActorItem,
+    CapabilityItem,
+    DomainItem,
+    SectionPlan,
+    SecurityPosture,
+    SpecBrief,
+)
+
+# Fixed document section order (the layered document, top → depth).
+_SECTIONS = [
+    "executive_summary",
+    "what_it_does",
+    "who_uses_it",
+    "how_work_flows",
+    "technical_foundation",
+    "compliance_posture",
+]
+
+
+def _user_entities(app: ir.AppSpec) -> list[ir.EntitySpec]:
+    """Entities the user actually modelled.
+
+    Excludes framework-injected platform plumbing (AIJob, FeedbackReport,
+    SystemHealth, …), which ``admin_builder`` stamps ``domain == "platform"`` by
+    construction (``_build_admin_entities``). These are infrastructure, not
+    "things the system manages", and must never surface in a stakeholder-facing
+    document. NB: ``cli/spec.py`` excludes the same set by *name*
+    (``_FRAMEWORK_INJECTED_ENTITIES``); the ``domain`` attribute is the more
+    robust signal and is preferred here.
+    """
+    return [e for e in app.domain.entities if e.domain != "platform"]
+
+
+def _user_surfaces(app: ir.AppSpec) -> list[ir.SurfaceSpec]:
+    """Surfaces the user actually modelled.
+
+    Excludes framework-injected plumbing that would misrepresent the system if
+    shown to a stakeholder, on two signals:
+      * admin dashboard surfaces (``_admin_health``, ``_admin_metrics``, …),
+        identified by the ``_admin_`` name prefix; and
+      * surfaces that target a framework ``platform`` entity (e.g. the
+        ``feedback_*`` surfaces over ``FeedbackReport``), which are not
+        ``_admin_``-prefixed but are still framework features, not product ones.
+    """
+    platform_names = {e.name for e in app.domain.entities if e.domain == "platform"}
+    return [
+        s
+        for s in app.surfaces
+        if not s.name.startswith("_admin_") and s.entity_ref not in platform_names
+    ]
+
+
+def build_brief(app: ir.AppSpec) -> SpecBrief:
+    """Extract verified facts and activate framework claims for ``app``."""
+    entities = _user_entities(app)
+    domain = [
+        DomainItem(
+            name=e.name,
+            title=e.title,
+            intent=e.intent,
+            lifecycle_states=(e.state_machine.state_names() if e.state_machine else []),
+        )
+        for e in entities
+    ]
+    actors = [ActorItem(id=p.id, label=p.label, description=p.description) for p in app.personas]
+    capabilities = [
+        CapabilityItem(name=s.name, title=s.title, entity=s.entity_ref, mode=s.mode.value)
+        for s in _user_surfaces(app)
+    ]
+    scoped = [e.name for e in entities if e.access is not None and e.access.scopes]
+    security = SecurityPosture(
+        has_row_level_security=bool(scoped),
+        scoped_entities=scoped,
+        persona_count=len(app.personas),
+    )
+    activated = _activate_claims(app)
+    skeleton = _plan_skeleton(app, entities, activated)
+    return SpecBrief(
+        app_name=app.name,
+        app_title=app.title,
+        domain=domain,
+        actors=actors,
+        capabilities=capabilities,
+        security=security,
+        activated_claims=activated,
+        skeleton=skeleton,
+    )
+
+
+def _activate_claims(app: ir.AppSpec) -> list[ActivatedClaim]:
+    """Run each catalogue claim's detector; keep those that fire (catalogue order)."""
+    out: list[ActivatedClaim] = []
+    for c in load_claims():
+        detector = REGISTRY.get(c.detector)
+        if detector is None:
+            # Gated for the bundled catalogue by the claim-integrity test, but a
+            # caller can pass a custom claims.toml via load_claims(path=...) —
+            # fail loud and specific rather than with a bare KeyError traceback.
+            raise ValueError(
+                f"Claim {c.id!r} references unknown detector {c.detector!r}. "
+                f"Known detectors: {sorted(REGISTRY)}"
+            )
+        if detector(app):
+            out.append(
+                ActivatedClaim(
+                    id=c.id, group=c.group, audience=c.audience, claim=c.claim, evidence=c.evidence
+                )
+            )
+    return out
+
+
+def _plan_skeleton(
+    app: ir.AppSpec, entities: list[ir.EntitySpec], activated: list[ActivatedClaim]
+) -> list[SectionPlan]:
+    """Decide which document sections are populated and which claims belong where."""
+    has_lifecycle = any(e.state_machine is not None for e in entities) or bool(app.approvals)
+    compliance_ids = [c.id for c in activated if c.group == "compliance"]
+    foundation_ids = [c.id for c in activated if c.group != "compliance"]
+    populated = {
+        "executive_summary": True,
+        "what_it_does": bool(entities),
+        "who_uses_it": bool(app.personas),
+        "how_work_flows": has_lifecycle,
+        "technical_foundation": bool(foundation_ids),
+        "compliance_posture": bool(compliance_ids),
+    }
+    claim_map = {
+        "technical_foundation": foundation_ids,
+        "compliance_posture": compliance_ids,
+    }
+    return [
+        SectionPlan(section=s, populated=populated[s], claim_ids=claim_map.get(s, []))
+        for s in _SECTIONS
+    ]

--- a/src/dazzle/spec_narrative/claims.py
+++ b/src/dazzle/spec_narrative/claims.py
@@ -1,0 +1,25 @@
+"""Framework value-claim catalogue: model + loader (claims.toml)."""
+
+import tomllib
+from pathlib import Path
+
+from pydantic import BaseModel
+
+_CLAIMS_PATH = Path(__file__).parent / "claims.toml"
+
+
+class Claim(BaseModel):
+    """A curated, stakeholder-facing statement about a framework guarantee."""
+
+    id: str
+    detector: str
+    group: str
+    audience: str
+    claim: str
+    evidence: str
+
+
+def load_claims(path: Path | None = None) -> list[Claim]:
+    """Load and validate the claim catalogue from ``claims.toml``."""
+    data = tomllib.loads((path or _CLAIMS_PATH).read_text(encoding="utf-8"))
+    return [Claim(id=claim_id, **body) for claim_id, body in data.items()]

--- a/src/dazzle/spec_narrative/claims.toml
+++ b/src/dazzle/spec_narrative/claims.toml
@@ -1,0 +1,103 @@
+# Framework value-claims surfaced in the generated SPECIFICATION.md.
+#
+# A claim appears in the brief ONLY when its `detector` (see detectors.REGISTRY)
+# returns True for the app — the document never asserts a capability the app does
+# not exercise.
+#
+# INTEGRITY RULE: a claim must not assert more than its detector proves. The
+# claim is shown to investors as fact. "Scope rules declared" (app-layer) is
+# weaker than "Postgres RLS enforced" (shared_schema tenancy); "rules declared"
+# is weaker than "rules verified"; "classifications declared" is weaker than
+# "audit evidence produced". The copy below is deliberately phrased as what is
+# *true today* for an app that fires the detector — capability, not aspiration.
+#
+# Fields per claim:
+#   detector  — name of a predicate in detectors.REGISTRY
+#   group     — document grouping: security | data | architecture | compliance
+#   audience  — primary reader: investor | founder | technical
+#   claim     — plain-English, jargon-free stakeholder statement
+#   evidence  — the command a skeptic runs to verify the claim
+
+[scope_filtering]
+detector = "has_rls"
+group = "security"
+audience = "investor"
+claim = """Access-controlled records are filtered to what each user is permitted
+to see. The rule is declared once in the model and applied automatically to every
+query the framework runs, instead of being re-implemented — and re-checked — on
+each screen."""
+evidence = "dazzle rbac report"
+
+[database_rls]
+detector = "has_database_rls"
+group = "security"
+audience = "investor"
+claim = """Because the system shares tables across tenants, the per-tenant
+boundary is enforced inside PostgreSQL itself through row-level security policies.
+The database refuses to return another tenant's rows even if the application code
+has a bug, because the rule lives in the data layer, not the app."""
+evidence = "dazzle db verify"
+
+[provable_rbac]
+detector = "has_provable_rbac"
+group = "security"
+audience = "investor"
+claim = """Every role's permissions, for every entity and operation, are declared
+as machine-readable policy. They compile on demand into an auditable access
+matrix — so permission review is something you run and diff, not something you
+eyeball."""
+evidence = "dazzle rbac report"
+
+[multi_tenant]
+detector = "is_multi_tenant"
+group = "security"
+audience = "founder"
+claim = """The system is multi-tenant: each customer's data is isolated from every
+other customer's at the data layer, so one organisation cannot see another
+organisation's records."""
+evidence = "dazzle tenant list"
+
+[postgres_backed]
+detector = "always"
+group = "data"
+audience = "technical"
+claim = """All data is stored in PostgreSQL — a mature, widely-trusted relational
+database. There is no bespoke or experimental datastore to operate, secure, or
+reason about."""
+evidence = "dazzle db status"
+
+[schema_managed]
+detector = "always"
+group = "data"
+audience = "technical"
+claim = """In production, every change to the data model is applied through
+versioned, reversible migrations. The live schema is never edited by hand, so
+upgrades are repeatable and fully auditable."""
+evidence = "dazzle db status"
+
+[server_rendered]
+detector = "always"
+group = "architecture"
+audience = "technical"
+claim = """The interface is rendered on the server and progressively enhanced.
+There is no heavy single-page JavaScript application to maintain, which keeps the
+product fast, accessible, and simple to operate."""
+evidence = "dazzle validate"
+
+[event_semantics]
+detector = "has_events"
+group = "architecture"
+audience = "technical"
+claim = """Significant business moments are modelled as first-class events with
+formally-defined semantics, giving the system a precise, auditable record of what
+happened and when."""
+evidence = "dazzle specs asyncapi"
+
+[compliance_evidence]
+detector = "has_compliance_evidence"
+group = "compliance"
+audience = "investor"
+claim = """Data classifications and controls declared in the model can be
+extracted into a compliance evidence report mapped to ISO 27001 and SOC 2
+controls, rather than assembled by hand at audit time."""
+evidence = "dazzle compliance summary"

--- a/src/dazzle/spec_narrative/detectors.py
+++ b/src/dazzle/spec_narrative/detectors.py
@@ -1,0 +1,79 @@
+"""Boolean predicates over an AppSpec that gate framework value-claims.
+
+A claim in ``claims.toml`` names one of these via its ``detector`` field; the
+claim only enters the brief when the predicate returns True for the app.
+
+Detector discipline: a detector must only return True for a property the app
+*genuinely* exercises. The whole feature's integrity rests on this — a claim is
+shown to investors as fact, so a detector that fires loosely produces a lie.
+In particular, "scope rules are declared" (app-layer filtering) is a strictly
+weaker property than "Postgres row-level security is enforced" (requires
+``shared_schema`` tenancy); they are deliberately split (``has_rls`` vs
+``has_database_rls``).
+"""
+
+from collections.abc import Callable
+
+from dazzle.core import ir
+from dazzle.core.ir.governance import TenancyMode
+
+
+def has_rls(app: ir.AppSpec) -> bool:
+    """True if any entity declares row-filtering scope rules (app-layer or DB)."""
+    return any(e.access is not None and bool(e.access.scopes) for e in app.domain.entities)
+
+
+def has_database_rls(app: ir.AppSpec) -> bool:
+    """True only when scope/tenant rules compile to *Postgres* RLS policies.
+
+    RLS DDL is generated solely for ``shared_schema`` tenancy
+    (see ``dazzle.http.runtime.rls_schema.build_all_rls_ddl``). Without it,
+    scope rules are enforced by application-layer query filtering, not by the
+    database — so the "even if the app has a bug" guarantee does not hold.
+    """
+    return app.tenancy is not None and app.tenancy.isolation.mode == TenancyMode.SHARED_SCHEMA
+
+
+def has_provable_rbac(app: ir.AppSpec) -> bool:
+    """True if personas are declared and at least one entity carries access rules."""
+    if not app.personas:
+        return False
+    return any(
+        e.access is not None and (bool(e.access.permissions) or bool(e.access.scopes))
+        for e in app.domain.entities
+    )
+
+
+def is_multi_tenant(app: ir.AppSpec) -> bool:
+    """True if the app declares genuine multi-tenant isolation.
+
+    A ``tenancy:`` block with ``mode = single`` is *not* multi-tenant, so the
+    bare ``app.tenancy is not None`` check would over-claim.
+    """
+    return app.tenancy is not None and app.tenancy.isolation.mode != TenancyMode.SINGLE
+
+
+def has_events(app: ir.AppSpec) -> bool:
+    """True if the app declares HLESS streams or an event model."""
+    return bool(app.streams) or app.event_model is not None
+
+
+def has_compliance_evidence(app: ir.AppSpec) -> bool:
+    """True if the app declares data classifications (compliance evidence source)."""
+    return app.policies is not None and bool(app.policies.classifications)
+
+
+def always(_app: ir.AppSpec) -> bool:
+    """For framework constants true of every Dazzle app (Postgres, SSR)."""
+    return True
+
+
+REGISTRY: dict[str, Callable[[ir.AppSpec], bool]] = {
+    "has_rls": has_rls,
+    "has_database_rls": has_database_rls,
+    "has_provable_rbac": has_provable_rbac,
+    "is_multi_tenant": is_multi_tenant,
+    "has_events": has_events,
+    "has_compliance_evidence": has_compliance_evidence,
+    "always": always,
+}

--- a/src/dazzle/spec_narrative/models.py
+++ b/src/dazzle/spec_narrative/models.py
@@ -1,0 +1,68 @@
+"""Pydantic IR for the spec brief — fact-only, no generated prose."""
+
+from pydantic import BaseModel, Field
+
+
+class DomainItem(BaseModel):
+    """A thing the system manages, in human terms."""
+
+    name: str
+    title: str | None = None
+    intent: str | None = None
+    lifecycle_states: list[str] = Field(default_factory=list)
+
+
+class ActorItem(BaseModel):
+    """A persona who uses the system."""
+
+    id: str
+    label: str
+    description: str | None = None
+
+
+class CapabilityItem(BaseModel):
+    """A surface — something an actor can do."""
+
+    name: str
+    title: str | None = None
+    entity: str | None = None
+    mode: str
+
+
+class SecurityPosture(BaseModel):
+    """The access model, summarised."""
+
+    has_row_level_security: bool
+    scoped_entities: list[str] = Field(default_factory=list)
+    persona_count: int
+
+
+class ActivatedClaim(BaseModel):
+    """A framework value-claim whose detector fired for this app."""
+
+    id: str
+    group: str
+    audience: str
+    claim: str
+    evidence: str
+
+
+class SectionPlan(BaseModel):
+    """Which document section is populated, and which claims belong in it."""
+
+    section: str
+    populated: bool
+    claim_ids: list[str] = Field(default_factory=list)
+
+
+class SpecBrief(BaseModel):
+    """The deterministic contract handed to the narrative stage."""
+
+    app_name: str
+    app_title: str | None = None
+    domain: list[DomainItem] = Field(default_factory=list)
+    actors: list[ActorItem] = Field(default_factory=list)
+    capabilities: list[CapabilityItem] = Field(default_factory=list)
+    security: SecurityPosture
+    activated_claims: list[ActivatedClaim] = Field(default_factory=list)
+    skeleton: list[SectionPlan] = Field(default_factory=list)

--- a/tests/unit/baselines/spec_brief_simple_task.json
+++ b/tests/unit/baselines/spec_brief_simple_task.json
@@ -1,0 +1,212 @@
+{
+  "app_name": "simple_task",
+  "app_title": "Team Task Manager",
+  "domain": [
+    {
+      "name": "User",
+      "title": "Team Member",
+      "intent": "A person with an account who can create and be assigned tasks within an organisation",
+      "lifecycle_states": []
+    },
+    {
+      "name": "Task",
+      "title": "Task",
+      "intent": "A unit of work assigned to a Team Member with a lifecycle from todo through review to done",
+      "lifecycle_states": [
+        "todo",
+        "in_progress",
+        "review",
+        "done"
+      ]
+    },
+    {
+      "name": "TaskComment",
+      "title": "Task Comment",
+      "intent": "A discussion note attached to a Task by a Team Member to capture context or decisions",
+      "lifecycle_states": []
+    }
+  ],
+  "actors": [
+    {
+      "id": "admin",
+      "label": "Administrator",
+      "description": "Full system access for task and user management"
+    },
+    {
+      "id": "manager",
+      "label": "Team Manager",
+      "description": "Oversee team tasks and assignments"
+    },
+    {
+      "id": "member",
+      "label": "Team Member",
+      "description": "Work on assigned tasks"
+    }
+  ],
+  "capabilities": [
+    {
+      "name": "task_list",
+      "title": "Task List",
+      "entity": "Task",
+      "mode": "list"
+    },
+    {
+      "name": "task_detail",
+      "title": "Task Detail",
+      "entity": "Task",
+      "mode": "view"
+    },
+    {
+      "name": "task_comments",
+      "title": "Task Comments",
+      "entity": "TaskComment",
+      "mode": "list"
+    },
+    {
+      "name": "comment_detail",
+      "title": "Comment Detail",
+      "entity": "TaskComment",
+      "mode": "view"
+    },
+    {
+      "name": "comment_create",
+      "title": "Add Comment",
+      "entity": "TaskComment",
+      "mode": "create"
+    },
+    {
+      "name": "comment_edit",
+      "title": "Edit Comment",
+      "entity": "TaskComment",
+      "mode": "edit"
+    },
+    {
+      "name": "task_create",
+      "title": "Create Task",
+      "entity": "Task",
+      "mode": "create"
+    },
+    {
+      "name": "task_edit",
+      "title": "Edit Task",
+      "entity": "Task",
+      "mode": "edit"
+    },
+    {
+      "name": "user_list",
+      "title": "Team Members",
+      "entity": "User",
+      "mode": "list"
+    },
+    {
+      "name": "user_detail",
+      "title": "Team Member Detail",
+      "entity": "User",
+      "mode": "view"
+    },
+    {
+      "name": "user_create",
+      "title": "Add Team Member",
+      "entity": "User",
+      "mode": "create"
+    },
+    {
+      "name": "user_edit",
+      "title": "Edit Team Member",
+      "entity": "User",
+      "mode": "edit"
+    }
+  ],
+  "security": {
+    "has_row_level_security": true,
+    "scoped_entities": [
+      "User",
+      "Task",
+      "TaskComment"
+    ],
+    "persona_count": 3
+  },
+  "activated_claims": [
+    {
+      "id": "scope_filtering",
+      "group": "security",
+      "audience": "investor",
+      "claim": "Access-controlled records are filtered to what each user is permitted\nto see. The rule is declared once in the model and applied automatically to every\nquery the framework runs, instead of being re-implemented — and re-checked — on\neach screen.",
+      "evidence": "dazzle rbac report"
+    },
+    {
+      "id": "provable_rbac",
+      "group": "security",
+      "audience": "investor",
+      "claim": "Every role's permissions, for every entity and operation, are declared\nas machine-readable policy. They compile on demand into an auditable access\nmatrix — so permission review is something you run and diff, not something you\neyeball.",
+      "evidence": "dazzle rbac report"
+    },
+    {
+      "id": "postgres_backed",
+      "group": "data",
+      "audience": "technical",
+      "claim": "All data is stored in PostgreSQL — a mature, widely-trusted relational\ndatabase. There is no bespoke or experimental datastore to operate, secure, or\nreason about.",
+      "evidence": "dazzle db status"
+    },
+    {
+      "id": "schema_managed",
+      "group": "data",
+      "audience": "technical",
+      "claim": "In production, every change to the data model is applied through\nversioned, reversible migrations. The live schema is never edited by hand, so\nupgrades are repeatable and fully auditable.",
+      "evidence": "dazzle db status"
+    },
+    {
+      "id": "server_rendered",
+      "group": "architecture",
+      "audience": "technical",
+      "claim": "The interface is rendered on the server and progressively enhanced.\nThere is no heavy single-page JavaScript application to maintain, which keeps the\nproduct fast, accessible, and simple to operate.",
+      "evidence": "dazzle validate"
+    },
+    {
+      "id": "event_semantics",
+      "group": "architecture",
+      "audience": "technical",
+      "claim": "Significant business moments are modelled as first-class events with\nformally-defined semantics, giving the system a precise, auditable record of what\nhappened and when.",
+      "evidence": "dazzle specs asyncapi"
+    }
+  ],
+  "skeleton": [
+    {
+      "section": "executive_summary",
+      "populated": true,
+      "claim_ids": []
+    },
+    {
+      "section": "what_it_does",
+      "populated": true,
+      "claim_ids": []
+    },
+    {
+      "section": "who_uses_it",
+      "populated": true,
+      "claim_ids": []
+    },
+    {
+      "section": "how_work_flows",
+      "populated": true,
+      "claim_ids": []
+    },
+    {
+      "section": "technical_foundation",
+      "populated": true,
+      "claim_ids": [
+        "scope_filtering",
+        "provable_rbac",
+        "postgres_backed",
+        "schema_managed",
+        "server_rendered",
+        "event_semantics"
+      ]
+    },
+    {
+      "section": "compliance_posture",
+      "populated": false,
+      "claim_ids": []
+    }
+  ]
+}

--- a/tests/unit/fixtures/deferred_imports_baseline.json
+++ b/tests/unit/fixtures/deferred_imports_baseline.json
@@ -297,7 +297,7 @@
   "src/dazzle/mcp/server/handlers/user_management.py": 1,
   "src/dazzle/mcp/server/handlers/user_profile.py": 4,
   "src/dazzle/mcp/server/handlers/viewport_testing.py": 5,
-  "src/dazzle/mcp/server/handlers_consolidated.py": 4,
+  "src/dazzle/mcp/server/handlers_consolidated.py": 6,
   "src/dazzle/mcp/server/state.py": 11,
   "src/dazzle/mcp/server/tool_handlers.py": 7,
   "src/dazzle/mcp/setup.py": 1,

--- a/tests/unit/test_spec_narrative_brief.py
+++ b/tests/unit/test_spec_narrative_brief.py
@@ -1,0 +1,181 @@
+"""SpecBrief models, builder, and CLI command."""
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from dazzle.cli.spec import spec_app
+from dazzle.core.appspec_loader import load_project_appspec
+from dazzle.spec_narrative.brief import build_brief
+from dazzle.spec_narrative.models import (
+    ActivatedClaim,
+    ActorItem,
+    CapabilityItem,
+    DomainItem,
+    SectionPlan,
+    SecurityPosture,
+    SpecBrief,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# --- models ---------------------------------------------------------------
+
+
+def test_spec_brief_serialises_round_trip():
+    brief = SpecBrief(
+        app_name="todo",
+        app_title="Todo App",
+        domain=[
+            DomainItem(name="Task", title="Task", intent=None, lifecycle_states=["open", "done"])
+        ],
+        actors=[ActorItem(id="member", label="Member", description=None)],
+        capabilities=[CapabilityItem(name="task_list", title="Tasks", entity="Task", mode="list")],
+        security=SecurityPosture(
+            has_row_level_security=True, scoped_entities=["Task"], persona_count=1
+        ),
+        activated_claims=[
+            ActivatedClaim(
+                id="row_level_security",
+                group="security",
+                audience="investor",
+                claim="x",
+                evidence="dazzle db verify",
+            )
+        ],
+        skeleton=[SectionPlan(section="executive_summary", populated=True, claim_ids=[])],
+    )
+    dumped = brief.model_dump_json()
+    restored = SpecBrief.model_validate_json(dumped)
+    assert restored == brief
+    assert restored.domain[0].lifecycle_states == ["open", "done"]
+
+
+# --- builder --------------------------------------------------------------
+
+
+def test_build_brief_plain_app_has_no_rls_claim():
+    # custom_renderer is a scope-free probe fixture.
+    brief = build_brief(load_project_appspec(REPO_ROOT / "fixtures/custom_renderer"))
+    assert brief.app_name
+    assert brief.domain, "expected at least one domain item"
+    assert brief.security.has_row_level_security is False
+    claim_ids = {c.id for c in brief.activated_claims}
+    assert "scope_filtering" not in claim_ids
+    assert "database_rls" not in claim_ids
+    # framework constants always present
+    assert "postgres_backed" in claim_ids
+    # every section appears in the skeleton, in fixed order
+    sections = [s.section for s in brief.skeleton]
+    assert sections == [
+        "executive_summary",
+        "what_it_does",
+        "who_uses_it",
+        "how_work_flows",
+        "technical_foundation",
+        "compliance_posture",
+    ]
+
+
+def test_build_brief_excludes_framework_platform_entities():
+    brief = build_brief(load_project_appspec(REPO_ROOT / "examples/simple_task"))
+    names = {d.name for d in brief.domain}
+    # user-modelled entities present
+    assert "Task" in names
+    # framework plumbing (domain == "platform") excluded
+    for plumbing in ("AIJob", "FeedbackReport", "SystemHealth", "SystemMetric", "DeployHistory"):
+        assert plumbing not in names, f"{plumbing} leaked into the stakeholder brief"
+
+
+def test_build_brief_scoped_but_untenanted_app_claims_app_layer_not_database_rls():
+    # rbac_validation: scope rules, NO tenancy → app-layer scope filtering only.
+    # It must NOT claim database-enforced RLS (the overstatement the split fixes).
+    brief = build_brief(load_project_appspec(REPO_ROOT / "fixtures/rbac_validation"))
+    claim_ids = {c.id for c in brief.activated_claims}
+    assert "scope_filtering" in claim_ids
+    assert "database_rls" not in claim_ids
+    assert brief.security.has_row_level_security is True
+    assert brief.security.scoped_entities, "expected scoped entity names"
+    tech = next(s for s in brief.skeleton if s.section == "technical_foundation")
+    assert "scope_filtering" in tech.claim_ids
+
+
+def test_build_brief_tenant_app_activates_database_rls_and_multi_tenant():
+    # tenant_rls: shared_schema tenancy → genuine Postgres RLS + multi-tenant.
+    brief = build_brief(load_project_appspec(REPO_ROOT / "fixtures/tenant_rls"))
+    claim_ids = {c.id for c in brief.activated_claims}
+    assert "database_rls" in claim_ids
+    assert "multi_tenant" in claim_ids
+
+
+def test_build_brief_excludes_framework_surfaces_from_capabilities():
+    brief = build_brief(load_project_appspec(REPO_ROOT / "examples/simple_task"))
+    cap_names = {c.name for c in brief.capabilities}
+    domain_names = {d.name for d in brief.domain}
+    for cap in brief.capabilities:
+        # no admin dashboard plumbing
+        assert not cap.name.startswith("_admin_"), f"admin surface {cap.name} leaked"
+        # no surface targeting a framework entity (e.g. FeedbackReport)
+        if cap.entity is not None:
+            assert cap.entity in domain_names, (
+                f"surface {cap.name} targets non-user entity {cap.entity}"
+            )
+    # the feedback widget surfaces (over framework FeedbackReport) are gone
+    assert "feedback_create" not in cap_names
+    assert "feedback_admin" not in cap_names
+
+
+def test_build_brief_compliance_section_only_when_evidence():
+    plain = build_brief(load_project_appspec(REPO_ROOT / "examples/simple_task"))
+    plain_compliance = next(s for s in plain.skeleton if s.section == "compliance_posture")
+    assert plain_compliance.populated is False
+
+
+# --- CLI ------------------------------------------------------------------
+
+
+def test_cli_spec_brief_emits_valid_json():
+    runner = CliRunner()
+    result = runner.invoke(
+        spec_app,
+        ["brief", "--project", str(REPO_ROOT / "examples/simple_task"), "--format", "json"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["app_name"]
+    assert isinstance(payload["activated_claims"], list)
+    assert any(c["id"] == "postgres_backed" for c in payload["activated_claims"])
+
+
+def test_cli_spec_brief_text_format_runs():
+    runner = CliRunner()
+    result = runner.invoke(
+        spec_app,
+        ["brief", "--project", str(REPO_ROOT / "examples/simple_task"), "--format", "text"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "SPEC BRIEF" in result.stdout
+
+
+# --- MCP read-op (dsl:brief) ----------------------------------------------
+
+
+def test_mcp_dsl_brief_op_returns_same_brief_as_builder():
+    from dazzle.mcp.server.handlers_consolidated import handle_dsl
+
+    out = handle_dsl(
+        {"operation": "brief", "project_path": str(REPO_ROOT / "examples/simple_task")}
+    )
+    payload = json.loads(out)
+    expected = build_brief(load_project_appspec(REPO_ROOT / "examples/simple_task"))
+    assert payload == json.loads(expected.model_dump_json(indent=2))
+
+
+def test_mcp_dsl_brief_op_in_registry_enum():
+    from dazzle.mcp.server.tools_consolidated import get_all_consolidated_tools
+
+    dsl_tool = next(t for t in get_all_consolidated_tools() if t.name == "dsl")
+    enum = dsl_tool.inputSchema["properties"]["operation"]["enum"]
+    assert "brief" in enum

--- a/tests/unit/test_spec_narrative_brief_snapshot.py
+++ b/tests/unit/test_spec_narrative_brief_snapshot.py
@@ -1,0 +1,36 @@
+"""Golden snapshot of the simple_task brief.
+
+Extraction changes are intentional and reviewable — they must not slip through
+silently. To accept a change:
+  1. Regenerate: dazzle spec brief -p examples/simple_task -f json \
+       > tests/unit/baselines/spec_brief_simple_task.json
+  2. Review the diff (and add a CHANGELOG entry if the public shape changed)
+  3. Commit the regenerated baseline
+"""
+
+from pathlib import Path
+
+from dazzle.core.appspec_loader import load_project_appspec
+from dazzle.spec_narrative.brief import build_brief
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BASELINE = Path(__file__).parent / "baselines" / "spec_brief_simple_task.json"
+
+
+def test_simple_task_brief_matches_baseline():
+    brief = build_brief(load_project_appspec(REPO_ROOT / "examples/simple_task"))
+    current = brief.model_dump_json(indent=2) + "\n"
+    assert BASELINE.exists(), (
+        f"Baseline missing. Generate it with:\n"
+        f"  dazzle spec brief -p examples/simple_task -f json > {BASELINE}"
+    )
+    expected = BASELINE.read_text(encoding="utf-8")
+    assert current == expected, (
+        "simple_task brief drifted from baseline. If intentional, regenerate:\n"
+        f"  dazzle spec brief -p examples/simple_task -f json > {BASELINE}"
+    )
+
+
+def test_brief_is_deterministic():
+    app = load_project_appspec(REPO_ROOT / "examples/simple_task")
+    assert build_brief(app).model_dump_json() == build_brief(app).model_dump_json()

--- a/tests/unit/test_spec_narrative_claims.py
+++ b/tests/unit/test_spec_narrative_claims.py
@@ -1,0 +1,32 @@
+"""Claim-catalogue loader + integrity drift gate."""
+
+from dazzle.spec_narrative.claims import load_claims
+from dazzle.spec_narrative.detectors import REGISTRY
+
+_ALLOWED_GROUPS = {"security", "data", "architecture", "compliance"}
+_ALLOWED_AUDIENCES = {"investor", "founder", "technical"}
+
+
+def test_claims_load():
+    claims = load_claims()
+    assert claims, "catalogue is empty"
+    ids = [c.id for c in claims]
+    assert len(ids) == len(set(ids)), "duplicate claim ids"
+    assert "scope_filtering" in ids
+
+
+def test_every_claim_detector_is_registered():
+    for c in load_claims():
+        assert c.detector in REGISTRY, f"claim {c.id!r} names unknown detector {c.detector!r}"
+
+
+def test_claim_groups_and_audiences_are_known():
+    for c in load_claims():
+        assert c.group in _ALLOWED_GROUPS, f"{c.id}: bad group {c.group!r}"
+        assert c.audience in _ALLOWED_AUDIENCES, f"{c.id}: bad audience {c.audience!r}"
+
+
+def test_claims_have_text_and_evidence():
+    for c in load_claims():
+        assert c.claim.strip(), f"{c.id}: empty claim text"
+        assert c.evidence.strip(), f"{c.id}: empty evidence command"

--- a/tests/unit/test_spec_narrative_detectors.py
+++ b/tests/unit/test_spec_narrative_detectors.py
@@ -1,0 +1,51 @@
+"""Detector behaviour for the spec-narrative pipeline."""
+
+from pathlib import Path
+
+from dazzle.core.appspec_loader import load_project_appspec
+from dazzle.spec_narrative.detectors import (
+    REGISTRY,
+    always,
+    has_database_rls,
+    has_rls,
+    is_multi_tenant,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load(rel: str):
+    return load_project_appspec(REPO_ROOT / rel)
+
+
+def test_has_rls_fires_for_scoped_fixture():
+    assert has_rls(_load("fixtures/rbac_validation")) is True
+
+
+def test_has_rls_false_for_plain_app():
+    # custom_renderer is a scope-free probe fixture (no `scope:` rules).
+    assert has_rls(_load("fixtures/custom_renderer")) is False
+
+
+def test_has_database_rls_requires_shared_schema_tenancy():
+    # tenant_rls uses shared_schema tenancy → real Postgres RLS.
+    assert has_database_rls(_load("fixtures/tenant_rls")) is True
+    # rbac_validation has scope rules but NO tenancy → app-layer filtering only,
+    # NOT database-enforced RLS. This is the false-positive the split prevents.
+    assert has_rls(_load("fixtures/rbac_validation")) is True
+    assert has_database_rls(_load("fixtures/rbac_validation")) is False
+
+
+def test_is_multi_tenant_fires_for_tenant_fixture():
+    assert is_multi_tenant(_load("fixtures/tenant_rls")) is True
+
+
+def test_always_is_always_true():
+    assert always(_load("examples/simple_task")) is True
+
+
+def test_registry_values_are_callable_and_return_bool():
+    app = _load("examples/simple_task")
+    for name, fn in REGISTRY.items():
+        result = fn(app)
+        assert isinstance(result, bool), f"{name} did not return bool"

--- a/uv.lock
+++ b/uv.lock
@@ -912,7 +912,7 @@ wheels = [
 
 [[package]]
 name = "dazzle-dsl"
-version = "0.88.9"
+version = "0.89.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Reverses the DSL→app flow into a non-technical `SPECIFICATION.md` for investors, business leaders, and founders. Two-stage pipeline matching Dazzle's Authoring-vs-API boundary:

- **Stage 1 — `dazzle spec brief`** (deterministic): extracts app facts (entities/personas/surfaces/lifecycles, framework plumbing filtered) + detector-gated framework value-claims (RLS, provable RBAC, Postgres, SSR, HLESS, multi-tenancy, compliance evidence). Also exposed as the `dsl` MCP tool's `brief` op.
- **Stage 2 — `/spec-narrate` skill** (agent-driven): renders the brief to a layered document; every sentence must trace to the brief, invents nothing.

New package `src/dazzle/spec_narrative/`. A claim activates only when its named detector fires, so the document never asserts a capability the app doesn't exercise — the core integrity invariant.

## Integrity hardening (from adversarial review)

Several claims originally overstated what their detector proved. Fixed so claim text matches the detector exactly:
- **Split RLS** into `scope_filtering` (app-layer, any scope rule) vs `database_rls` (only `shared_schema` tenancy → real Postgres RLS). Prevents falsely telling investors data is database-enforced when scopes are app-layer only.
- Softened `provable_rbac` (declared+compilable, not "already verified"), `compliance_evidence` ("can be extracted"), `schema_managed` (production-scoped).
- Tightened `is_multi_tenant` to exclude `mode=single`.
- Filter framework plumbing: platform-domain entities **and** the surfaces targeting them (`feedback_*`), plus `_admin_` dashboard surfaces.

## Tests & gates

- 23 new tests (detectors, claim-integrity gate, builder, CLI, MCP op, golden brief snapshot)
- Drift baselines regenerated (`mcp-tools` api-surface) with CHANGELOG entry
- Deferred-import ratchet handled: `cli/spec.py` hoisted to module top; `handlers_consolidated.py` baseline 4→6 (intentional MCP-startup-perf deferral, consistent with the existing `load_project_appspec` deferral)
- ruff + mypy clean, 371 gate tests, mkdocs `--strict` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🔖 Claude-lens: dazzle